### PR TITLE
feat: add REST API for MCP server configuration management

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,10 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { createServer, IncomingMessage, ServerResponse } from "http";
-import { MCPClientManager } from "./services/connector/mcp-clients/client.js";
+import {
+  MCPClientManager,
+  MCPServerConfig,
+} from "./services/connector/mcp-clients/client.js";
 import { loadProxyConfig, validateConfig } from "./mcp/config-loader.js";
 import { localTools, proxyTools } from "./mcp/tools.js";
 import { handleLocalTool, handleProxyTool } from "./mcp/handlers.js";
@@ -14,6 +17,7 @@ import {
   initializeRemoteServers,
   shutdownServices,
 } from "./mcp/initialization.js";
+import { MCPServerConfigModel } from "./shared/database/mongoose.js";
 
 const mcpClientManager = new MCPClientManager();
 
@@ -97,6 +101,7 @@ const readBody = (req: IncomingMessage): Promise<string> => {
 // Start server
 const runServer = async () => {
   const remoteServerConfigs = loadProxyConfig();
+  await initializeServices();
 
   const validConfigs = remoteServerConfigs.filter((config) => {
     const error = validateConfig(config);
@@ -137,6 +142,336 @@ const runServer = async () => {
       if (req.url === "/health") {
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ status: "ok", version: "0.1.0" }));
+        return;
+      }
+
+      // MCP Server Config REST API endpoints
+      // GET /api/mcp-servers - List all MCP server configs
+      if (req.url === "/api/mcp-servers" && req.method === "GET") {
+        try {
+          const configs = await MCPServerConfigModel.find().sort({
+            createdAt: -1,
+          });
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ success: true, data: configs }));
+        } catch (error) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          );
+        }
+        return;
+      }
+
+      // POST /api/mcp-servers - Create a new MCP server config
+      if (req.url === "/api/mcp-servers" && req.method === "POST") {
+        try {
+          const body = await readBody(req);
+          const configData: MCPServerConfig = JSON.parse(body);
+
+          // Validate the config
+          const validationError = validateConfig(configData);
+          if (validationError) {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ success: false, error: validationError }));
+            return;
+          }
+
+          // Create and save the config
+          const config = new MCPServerConfigModel(configData);
+          await config.save();
+
+          // Optionally connect to the server immediately
+          if (configData.name) {
+            try {
+              await mcpClientManager.connect(configData);
+              console.error(
+                `✅ Auto-connected to new MCP server: ${configData.name}`
+              );
+            } catch (connectError) {
+              console.error(
+                `⚠️  Failed to auto-connect to ${configData.name}:`,
+                connectError
+              );
+            }
+          }
+
+          res.writeHead(201, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ success: true, data: config }));
+        } catch (error) {
+          const statusCode = (error as any).code === 11000 ? 409 : 500;
+          res.writeHead(statusCode, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          );
+        }
+        return;
+      }
+
+      // GET /api/mcp-servers/:name - Get a specific MCP server config
+      const getMatch = req.url?.match(/^\/api\/mcp-servers\/([^/]+)$/);
+      if (getMatch && req.method === "GET") {
+        try {
+          const name = decodeURIComponent(getMatch[1]);
+          const config = await MCPServerConfigModel.findOne({ name });
+
+          if (!config) {
+            res.writeHead(404, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                success: false,
+                error: "MCP server config not found",
+              })
+            );
+            return;
+          }
+
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ success: true, data: config }));
+        } catch (error) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          );
+        }
+        return;
+      }
+
+      // PUT /api/mcp-servers/:name - Update an MCP server config
+      const putMatch = req.url?.match(/^\/api\/mcp-servers\/([^/]+)$/);
+      if (putMatch && req.method === "PUT") {
+        try {
+          const name = decodeURIComponent(putMatch[1]);
+          const body = await readBody(req);
+          const updateData: Partial<MCPServerConfig> = JSON.parse(body);
+
+          // Don't allow changing the name
+          delete (updateData as any).name;
+
+          // Validate if type is being changed
+          if (updateData.type) {
+            const tempConfig = { ...updateData, name } as MCPServerConfig;
+            const validationError = validateConfig(tempConfig);
+            if (validationError) {
+              res.writeHead(400, { "Content-Type": "application/json" });
+              res.end(
+                JSON.stringify({ success: false, error: validationError })
+              );
+              return;
+            }
+          }
+
+          const config = await MCPServerConfigModel.findOneAndUpdate(
+            { name },
+            updateData,
+            { new: true, runValidators: true }
+          );
+
+          if (!config) {
+            res.writeHead(404, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                success: false,
+                error: "MCP server config not found",
+              })
+            );
+            return;
+          }
+
+          // Reconnect if the server is currently connected
+          if (mcpClientManager.isConnected(name)) {
+            try {
+              await mcpClientManager.disconnect(name);
+              await mcpClientManager.connect(
+                config.toObject() as MCPServerConfig
+              );
+              console.error(`✅ Reconnected to updated MCP server: ${name}`);
+            } catch (reconnectError) {
+              console.error(
+                `⚠️  Failed to reconnect to ${name}:`,
+                reconnectError
+              );
+            }
+          }
+
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ success: true, data: config }));
+        } catch (error) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          );
+        }
+        return;
+      }
+
+      // DELETE /api/mcp-servers/:name - Delete an MCP server config
+      const deleteMatch = req.url?.match(/^\/api\/mcp-servers\/([^/]+)$/);
+      if (deleteMatch && req.method === "DELETE") {
+        try {
+          const name = decodeURIComponent(deleteMatch[1]);
+
+          // Disconnect if currently connected
+          if (mcpClientManager.isConnected(name)) {
+            await mcpClientManager.disconnect(name);
+          }
+
+          const config = await MCPServerConfigModel.findOneAndDelete({ name });
+
+          if (!config) {
+            res.writeHead(404, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                success: false,
+                error: "MCP server config not found",
+              })
+            );
+            return;
+          }
+
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              success: true,
+              message: "MCP server config deleted",
+            })
+          );
+        } catch (error) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          );
+        }
+        return;
+      }
+
+      // POST /api/mcp-servers/:name/connect - Connect to an MCP server
+      const connectMatch = req.url?.match(
+        /^\/api\/mcp-servers\/([^/]+)\/connect$/
+      );
+      if (connectMatch && req.method === "POST") {
+        try {
+          console.log("?????");
+          const name = decodeURIComponent(connectMatch[1]);
+          const config = await MCPServerConfigModel.findOne({ name });
+
+          if (!config) {
+            res.writeHead(404, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                success: false,
+                error: "MCP server config not found",
+              })
+            );
+            return;
+          }
+
+          if (mcpClientManager.isConnected(name)) {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                success: false,
+                error: "Server already connected",
+              })
+            );
+            return;
+          }
+
+          await mcpClientManager.connect(config.toObject() as MCPServerConfig);
+
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({ success: true, message: `Connected to ${name}` })
+          );
+        } catch (error) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          );
+        }
+        return;
+      }
+
+      // POST /api/mcp-servers/:name/disconnect - Disconnect from an MCP server
+      const disconnectMatch = req.url?.match(
+        /^\/api\/mcp-servers\/([^/]+)\/disconnect$/
+      );
+      if (disconnectMatch && req.method === "POST") {
+        try {
+          const name = decodeURIComponent(disconnectMatch[1]);
+
+          if (!mcpClientManager.isConnected(name)) {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({ success: false, error: "Server not connected" })
+            );
+            return;
+          }
+
+          await mcpClientManager.disconnect(name);
+
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              success: true,
+              message: `Disconnected from ${name}`,
+            })
+          );
+        } catch (error) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          );
+        }
+        return;
+      }
+
+      // GET /api/mcp-servers/:name/status - Get connection status
+      const statusMatch = req.url?.match(
+        /^\/api\/mcp-servers\/([^/]+)\/status$/
+      );
+      if (statusMatch && req.method === "GET") {
+        try {
+          const name = decodeURIComponent(statusMatch[1]);
+          const isConnected = mcpClientManager.isConnected(name);
+
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              success: true,
+              data: { name, connected: isConnected },
+            })
+          );
+        } catch (error) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          );
+        }
         return;
       }
 

--- a/src/mcp/initialization.ts
+++ b/src/mcp/initialization.ts
@@ -9,9 +9,14 @@ import {
   MCPClientManager,
   MCPServerConfig,
 } from "../services/connector/mcp-clients/client.js";
+import {
+  connectMongoose,
+  MongooseConnection,
+} from "../shared/database/mongoose.js";
 
 export interface ServiceConnections {
   mongo: MongoConnection;
+  mongoose: MongooseConnection;
   qdrant: QdrantConnection;
   memgraph: MemgraphConnection;
   redis: RedisConnection;
@@ -26,14 +31,15 @@ export async function initializeServices(): Promise<ServiceConnections> {
 
   console.error("🚀 Initializing eBee services...");
 
-  const [mongo, qdrant, memgraph, redis] = await Promise.all([
+  const [mongo, mongoose, qdrant, memgraph, redis] = await Promise.all([
     connectMongo(),
+    connectMongoose(),
     connectQdrant(),
     connectMemgraph(),
     connectRedis(),
   ]);
 
-  services = { mongo, qdrant, memgraph, redis };
+  services = { mongo, mongoose, qdrant, memgraph, redis };
   console.error("✅ All services initialized successfully!");
   return services;
 }

--- a/src/services/indexer/index.ts
+++ b/src/services/indexer/index.ts
@@ -3,6 +3,10 @@ import { IndexRequest, IndexResponse } from "../../contracts/index.js";
 import { IndexingService } from "../indexing/indexing.service.js";
 import { env } from "../../env.js";
 import { Redis } from "ioredis";
+import { MCPServerConfigModel } from "../../shared/database/mongoose.js";
+import { MCPClientManager } from "../connector/mcp-clients/client.js";
+import { NotionMCPClient } from "./notion/mcpClient.js";
+import { indexNotionWorkspace } from "./notion/indexer.js";
 
 /**
  * Indexer Service - Worker + Queue System
@@ -364,3 +368,93 @@ export class IndexerService {
     console.log("[Indexer] Shutdown complete");
   }
 }
+
+/**
+ * Index all MCP servers from MongoDB
+ * Connects to each server and runs the appropriate indexer
+ */
+export const indexMcpServers = async () => {
+  console.log("🔍 Starting MCP servers indexing...");
+
+  try {
+    // Get all MCP server configs from MongoDB
+    const mcpServers = await MCPServerConfigModel.find({});
+
+    if (mcpServers.length === 0) {
+      console.log("⚠️  No MCP servers found in database");
+      return;
+    }
+
+    console.log(`📋 Found ${mcpServers.length} MCP server(s) to index`);
+
+    // Create MCP client manager
+    const mcpClientManager = new MCPClientManager();
+
+    // Process each server
+    for (const serverConfig of mcpServers) {
+      try {
+        console.log(`\n🔌 Connecting to ${serverConfig.name}...`);
+
+        // Convert Mongoose Map to plain object
+        const envObj = serverConfig.env
+          ? Object.fromEntries(serverConfig.env as any)
+          : undefined;
+        const headersObj = serverConfig.headers
+          ? Object.fromEntries(serverConfig.headers as any)
+          : undefined;
+
+        // Connect to the MCP server
+        await mcpClientManager.connect({
+          name: serverConfig.name,
+          type: serverConfig.type,
+          command: serverConfig.command,
+          args: serverConfig.args,
+          env: envObj,
+          url: serverConfig.url,
+          headers: headersObj,
+        });
+
+        // Run the appropriate indexer based on server name/type
+        if (serverConfig.name.toLowerCase().includes("notion")) {
+          console.log(`📝 Running Notion indexer for ${serverConfig.name}...`);
+
+          const notionClient = new NotionMCPClient(mcpClientManager);
+          const result = await indexNotionWorkspace(notionClient, {
+            include_comments: true,
+            include_archived: false,
+            max_retries: 3,
+            rate_limit_delay: 350,
+          });
+
+          if (result.success) {
+            console.log(
+              `✅ Successfully indexed ${serverConfig.name}: ${result.summary.total_entities} entities`
+            );
+          } else {
+            console.error(
+              `❌ Failed to index ${serverConfig.name}:`,
+              result.progress.errors
+            );
+          }
+        } else {
+          console.log(
+            `⚠️  No indexer available for ${serverConfig.name} (type: ${serverConfig.type})`
+          );
+        }
+
+        // Disconnect from the server
+        await mcpClientManager.disconnect(serverConfig.name);
+      } catch (error) {
+        console.error(
+          `❌ Error indexing ${serverConfig.name}:`,
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+    }
+
+    console.log("\n✅ MCP servers indexing completed");
+  } catch (error) {
+    console.error("❌ Error in indexMcpServers:", error);
+    throw error;
+  }
+};

--- a/src/services/indexer/notion/indexer.ts
+++ b/src/services/indexer/notion/indexer.ts
@@ -1,0 +1,480 @@
+import { NotionMCPClient } from "./mcpClient.js";
+import {
+  NotionUser,
+  NotionPage,
+  NotionDatabase,
+  NotionBlock,
+  NotionComment,
+  IndexerProgress,
+  IndexerOptions,
+  IndexerResult,
+} from "./types.js";
+
+/**
+ * Functional Notion Indexer
+ * Pure functions for extracting and transforming Notion data
+ */
+
+// ============================================================================
+// Core Extraction Functions
+// ============================================================================
+
+/**
+ * Extract all users from workspace
+ */
+export const extractUsers = async (
+  client: NotionMCPClient
+): Promise<{ bot: NotionUser; users: NotionUser[] }> => {
+  const [bot, users] = await Promise.all([
+    client.getBotInfo(),
+    client.getAllUsers(),
+  ]);
+
+  return { bot, users };
+};
+
+/**
+ * Extract all pages and databases from workspace
+ */
+export const extractWorkspaceContent = async (
+  client: NotionMCPClient
+): Promise<{ pages: NotionPage[]; databases: NotionDatabase[] }> => {
+  const [pages, databases] = await Promise.all([
+    client.searchAllPages(),
+    client.searchAllDatabases(),
+  ]);
+
+  return { pages, databases };
+};
+
+/**
+ * Extract database schema and all its rows
+ */
+export const extractDatabase = async (
+  client: NotionMCPClient,
+  databaseId: string
+): Promise<{ schema: NotionDatabase; rows: NotionPage[] }> => {
+  const [schema, rows] = await Promise.all([
+    client.getDatabaseSchema(databaseId),
+    client.queryDatabaseRows(databaseId),
+  ]);
+
+  return { schema, rows };
+};
+
+/**
+ * Extract all databases with their schemas and rows
+ */
+export const extractAllDatabases = async (
+  client: NotionMCPClient,
+  databases: NotionDatabase[]
+): Promise<Array<{ schema: NotionDatabase; rows: NotionPage[] }>> => {
+  return Promise.all(databases.map((db) => extractDatabase(client, db.id)));
+};
+
+/**
+ * Extract page content including metadata and blocks
+ */
+export const extractPageContent = async (
+  client: NotionMCPClient,
+  pageId: string,
+  includeComments: boolean = true
+): Promise<{
+  page: NotionPage;
+  blocks: NotionBlock[];
+  comments: NotionComment[];
+}> => {
+  const page = await client.getPage(pageId);
+  const blocks = await client.getAllBlocksRecursive(pageId);
+  const comments = includeComments ? await client.getPageComments(pageId) : [];
+
+  return { page, blocks, comments };
+};
+
+/**
+ * Extract content for multiple pages
+ */
+export const extractAllPagesContent = async (
+  client: NotionMCPClient,
+  pages: NotionPage[],
+  includeComments: boolean = true
+): Promise<
+  Array<{
+    page: NotionPage;
+    blocks: NotionBlock[];
+    comments: NotionComment[];
+  }>
+> => {
+  return Promise.all(
+    pages.map((page) => extractPageContent(client, page.id, includeComments))
+  );
+};
+
+// ============================================================================
+// Data Transformation Functions
+// ============================================================================
+
+/**
+ * Extract text content from rich text array
+ */
+export const extractTextFromRichText = (
+  richText: Array<{ type: string; text: { content: string } }>
+): string => {
+  return richText.map((rt) => rt.text?.content || "").join("");
+};
+
+/**
+ * Extract text content from a block
+ */
+export const extractBlockText = (block: NotionBlock): string => {
+  const blockType = block.type;
+  const blockData = block[blockType];
+
+  if (blockData && blockData.rich_text) {
+    return extractTextFromRichText(blockData.rich_text);
+  }
+
+  return "";
+};
+
+/**
+ * Flatten block hierarchy into a list with depth information
+ */
+export const flattenBlocks = (
+  blocks: NotionBlock[],
+  depth: number = 0
+): Array<NotionBlock & { depth: number }> => {
+  return blocks.map((block) => ({
+    ...block,
+    depth,
+  }));
+};
+
+/**
+ * Extract all text content from blocks
+ */
+export const extractAllBlockText = (blocks: NotionBlock[]): string => {
+  return blocks.map(extractBlockText).filter(Boolean).join("\n\n");
+};
+
+/**
+ * Build page document for MongoDB
+ */
+export const buildPageDocument = (
+  page: NotionPage,
+  blocks: NotionBlock[],
+  comments: NotionComment[]
+) => {
+  const textContent = extractAllBlockText(blocks);
+
+  return {
+    _id: `notion_page_${page.id}`,
+    notion_id: page.id,
+    type: "page",
+    title: extractTextFromRichText((page.properties.title as any)?.title || []),
+    properties: page.properties,
+    parent: page.parent,
+    content_text: textContent,
+    blocks: blocks.map((b) => ({
+      id: b.id,
+      type: b.type,
+      text: extractBlockText(b),
+      has_children: b.has_children,
+    })),
+    comments_count: comments.length,
+    metadata: {
+      created_time: page.created_time,
+      last_edited_time: page.last_edited_time,
+      created_by: page.created_by,
+      last_edited_by: page.last_edited_by,
+      url: page.url,
+      icon: page.icon,
+      cover: page.cover,
+    },
+    indexed_at: new Date().toISOString(),
+  };
+};
+
+/**
+ * Build database document for MongoDB
+ */
+export const buildDatabaseDocument = (
+  database: NotionDatabase,
+  rows: NotionPage[]
+) => {
+  return {
+    _id: `notion_database_${database.id}`,
+    notion_id: database.id,
+    type: "database",
+    title: extractTextFromRichText(database.title),
+    description: extractTextFromRichText(database.description || []),
+    properties: database.properties,
+    parent: database.parent,
+    row_count: rows.length,
+    row_ids: rows.map((r) => r.id),
+    metadata: {
+      created_time: database.created_time,
+      last_edited_time: database.last_edited_time,
+      created_by: database.created_by,
+      last_edited_by: database.last_edited_by,
+      url: database.url,
+      icon: database.icon,
+      cover: database.cover,
+    },
+    indexed_at: new Date().toISOString(),
+  };
+};
+
+/**
+ * Build user document for MongoDB
+ */
+export const buildUserDocument = (user: NotionUser) => {
+  return {
+    _id: `notion_user_${user.id}`,
+    notion_id: user.id,
+    type: "user",
+    user_type: user.type,
+    name: user.name,
+    avatar_url: user.avatar_url,
+    email: user.person?.email,
+    indexed_at: new Date().toISOString(),
+  };
+};
+
+/**
+ * Build comment document for MongoDB
+ */
+export const buildCommentDocument = (
+  comment: NotionComment,
+  pageId: string
+) => {
+  return {
+    _id: `notion_comment_${comment.id}`,
+    notion_id: comment.id,
+    type: "comment",
+    page_id: pageId,
+    discussion_id: comment.discussion_id,
+    text: extractTextFromRichText(comment.rich_text),
+    created_by: comment.created_by,
+    created_time: comment.created_time,
+    last_edited_time: comment.last_edited_time,
+    indexed_at: new Date().toISOString(),
+  };
+};
+
+// ============================================================================
+// Progress Tracking Functions
+// ============================================================================
+
+/**
+ * Create initial progress state
+ */
+export const createInitialProgress = (jobId: string): IndexerProgress => ({
+  job_id: jobId,
+  started_at: new Date().toISOString(),
+  status: "running",
+  current_phase: "initialization",
+  progress: {
+    users: { total: 0, processed: 0 },
+    databases: { total: 0, processed: 0 },
+    pages: { total: 0, processed: 0 },
+    blocks: { total: 0, processed: 0 },
+    comments: { total: 0, processed: 0 },
+  },
+  errors: [],
+  last_updated: new Date().toISOString(),
+});
+
+/**
+ * Update progress phase
+ */
+export const updateProgressPhase = (
+  progress: IndexerProgress,
+  phase: string
+): IndexerProgress => ({
+  ...progress,
+  current_phase: phase,
+  last_updated: new Date().toISOString(),
+});
+
+/**
+ * Update progress counts
+ */
+export const updateProgressCounts = (
+  progress: IndexerProgress,
+  entity: keyof IndexerProgress["progress"],
+  total: number,
+  processed: number
+): IndexerProgress => ({
+  ...progress,
+  progress: {
+    ...progress.progress,
+    [entity]: { total, processed },
+  },
+  last_updated: new Date().toISOString(),
+});
+
+/**
+ * Add error to progress
+ */
+export const addProgressError = (
+  progress: IndexerProgress,
+  entityId: string,
+  entityType: string,
+  error: string
+): IndexerProgress => ({
+  ...progress,
+  errors: [
+    ...progress.errors,
+    {
+      entity_id: entityId,
+      entity_type: entityType,
+      error,
+      timestamp: new Date().toISOString(),
+    },
+  ],
+  last_updated: new Date().toISOString(),
+});
+
+/**
+ * Complete progress
+ */
+export const completeProgress = (
+  progress: IndexerProgress,
+  status: "completed" | "failed"
+): IndexerProgress => ({
+  ...progress,
+  status,
+  last_updated: new Date().toISOString(),
+});
+
+// ============================================================================
+// Main Orchestration Function
+// ============================================================================
+
+/**
+ * Execute full Notion workspace indexing
+ */
+export const indexNotionWorkspace = async (
+  client: NotionMCPClient,
+  options: IndexerOptions
+): Promise<IndexerResult> => {
+  const jobId = `notion_index_${Date.now()}`;
+  const startTime = Date.now();
+  let progress = createInitialProgress(jobId);
+
+  try {
+    // Phase 1: Extract users
+    progress = updateProgressPhase(progress, "extracting_users");
+    const { users } = await extractUsers(client);
+    progress = updateProgressCounts(
+      progress,
+      "users",
+      users.length,
+      users.length
+    );
+
+    // Phase 2: Extract workspace content
+    progress = updateProgressPhase(progress, "discovering_content");
+    const { pages, databases } = await extractWorkspaceContent(client);
+    progress = updateProgressCounts(progress, "databases", databases.length, 0);
+    progress = updateProgressCounts(progress, "pages", pages.length, 0);
+
+    // Phase 3: Extract databases
+    progress = updateProgressPhase(progress, "extracting_databases");
+    const databasesData = await extractAllDatabases(client, databases);
+    progress = updateProgressCounts(
+      progress,
+      "databases",
+      databases.length,
+      databases.length
+    );
+
+    // Phase 4: Extract page content
+    progress = updateProgressPhase(progress, "extracting_pages");
+    const allPages = [...pages, ...databasesData.flatMap((db) => db.rows)];
+    const uniquePages = Array.from(
+      new Map(allPages.map((p) => [p.id, p])).values()
+    );
+
+    const pagesContent = await extractAllPagesContent(
+      client,
+      uniquePages,
+      options.include_comments
+    );
+
+    progress = updateProgressCounts(
+      progress,
+      "pages",
+      uniquePages.length,
+      uniquePages.length
+    );
+
+    const totalBlocks = pagesContent.reduce(
+      (sum, pc) => sum + pc.blocks.length,
+      0
+    );
+    const totalComments = pagesContent.reduce(
+      (sum, pc) => sum + pc.comments.length,
+      0
+    );
+
+    progress = updateProgressCounts(
+      progress,
+      "blocks",
+      totalBlocks,
+      totalBlocks
+    );
+    progress = updateProgressCounts(
+      progress,
+      "comments",
+      totalComments,
+      totalComments
+    );
+
+    // Complete
+    progress = completeProgress(progress, "completed");
+
+    const duration = Date.now() - startTime;
+    const totalEntities =
+      users.length +
+      databases.length +
+      uniquePages.length +
+      totalBlocks +
+      totalComments;
+
+    // TODO: save data in mongo, qdrant etc...
+
+    return {
+      success: true,
+      job_id: jobId,
+      progress,
+      summary: {
+        total_entities: totalEntities,
+        successful: totalEntities - progress.errors.length,
+        failed: progress.errors.length,
+        duration_ms: duration,
+      },
+    };
+  } catch (error) {
+    progress = completeProgress(progress, "failed");
+    progress = addProgressError(
+      progress,
+      "workspace",
+      "workspace",
+      error instanceof Error ? error.message : String(error)
+    );
+
+    return {
+      success: false,
+      job_id: jobId,
+      progress,
+      summary: {
+        total_entities: 0,
+        successful: 0,
+        failed: 1,
+        duration_ms: Date.now() - startTime,
+      },
+    };
+  }
+};

--- a/src/services/indexer/notion/mcpClient.ts
+++ b/src/services/indexer/notion/mcpClient.ts
@@ -1,0 +1,262 @@
+import { MCPClientManager } from "../../connector/mcp-clients/client.js";
+import {
+  NotionUser,
+  NotionPage,
+  NotionDatabase,
+  NotionBlock,
+  NotionComment,
+} from "./types.js";
+
+/**
+ * Notion MCP Client wrapper for data extraction
+ */
+export class NotionMCPClient {
+  private serverName = "notion";
+  private rateLimitDelay = 350; // 350ms = ~3 requests per second
+
+  constructor(private mcpClient: MCPClientManager) {}
+
+  /**
+   * Sleep utility for rate limiting
+   */
+  private async sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Call MCP tool with rate limiting and parse response
+   */
+  private async callTool<T>(
+    toolName: string,
+    args: Record<string, any>
+  ): Promise<T> {
+    await this.sleep(this.rateLimitDelay);
+    const response = await this.mcpClient.callTool(
+      this.serverName,
+      toolName,
+      args
+    );
+
+    // MCP response format: { content: [{ type: 'text', text: '...' }] }
+    if (response && response.content && Array.isArray(response.content)) {
+      const textContent = response.content.find((c: any) => c.type === "text");
+      if (textContent && textContent.text) {
+        try {
+          return JSON.parse(textContent.text) as T;
+        } catch (error) {
+          console.error("Failed to parse MCP response:", error);
+          throw new Error(
+            `Invalid JSON in MCP response: ${textContent.text.substring(
+              0,
+              100
+            )}...`
+          );
+        }
+      }
+    }
+
+    // Fallback: return response as-is if it doesn't match expected format
+    return response as T;
+  }
+
+  /**
+   * Generic pagination handler
+   */
+  private async fetchAllPages<T>(
+    toolName: string,
+    params: Record<string, any>,
+    extractResults: (response: any) => T[]
+  ): Promise<T[]> {
+    const allResults: T[] = [];
+    let cursor: string | undefined = undefined;
+
+    do {
+      const response: any = await this.callTool(toolName, {
+        ...params,
+        start_cursor: cursor,
+        page_size: 100,
+      });
+
+      const results = extractResults(response);
+      allResults.push(...results);
+
+      cursor = response.next_cursor || undefined;
+    } while (cursor);
+
+    return allResults;
+  }
+
+  /**
+   * Phase 1: Get bot information
+   */
+  async getBotInfo(): Promise<NotionUser> {
+    return this.callTool<NotionUser>("API-get-self", {});
+  }
+
+  /**
+   * Phase 1: Get all workspace users
+   */
+  async getAllUsers(): Promise<NotionUser[]> {
+    return this.fetchAllPages<NotionUser>(
+      "API-get-users",
+      {},
+      (response) => response.results
+    );
+  }
+
+  /**
+   * Phase 1: Get specific user details
+   */
+  async getUser(userId: string): Promise<NotionUser> {
+    return this.callTool<NotionUser>("API-get-user", { user_id: userId });
+  }
+
+  /**
+   * Phase 2: Search all pages
+   */
+  async searchAllPages(): Promise<NotionPage[]> {
+    return this.fetchAllPages<NotionPage>(
+      "API-post-search",
+      {
+        query: "",
+        filter: {
+          value: "page",
+          property: "object",
+        },
+        sort: {
+          direction: "descending",
+          timestamp: "last_edited_time",
+        },
+      },
+      (response) => response.results
+    );
+  }
+
+  /**
+   * Phase 2: Search all databases
+   */
+  async searchAllDatabases(): Promise<NotionDatabase[]> {
+    return this.fetchAllPages<NotionDatabase>(
+      "API-post-search",
+      {
+        query: "",
+        filter: {
+          value: "database",
+          property: "object",
+        },
+        sort: {
+          direction: "descending",
+          timestamp: "last_edited_time",
+        },
+      },
+      (response) => response.results
+    );
+  }
+
+  /**
+   * Phase 3: Get database schema
+   */
+  async getDatabaseSchema(databaseId: string): Promise<NotionDatabase> {
+    return this.callTool<NotionDatabase>("API-retrieve-a-database", {
+      database_id: databaseId,
+    });
+  }
+
+  /**
+   * Phase 3: Query all database rows
+   */
+  async queryDatabaseRows(databaseId: string): Promise<NotionPage[]> {
+    return this.fetchAllPages<NotionPage>(
+      "API-post-database-query",
+      {
+        database_id: databaseId,
+      },
+      (response) => response.results
+    );
+  }
+
+  /**
+   * Phase 4: Get page metadata
+   */
+  async getPage(pageId: string): Promise<NotionPage> {
+    return this.callTool<NotionPage>("API-retrieve-a-page", {
+      page_id: pageId,
+    });
+  }
+
+  /**
+   * Phase 4: Get page content blocks
+   */
+  async getBlockChildren(blockId: string): Promise<NotionBlock[]> {
+    return this.fetchAllPages<NotionBlock>(
+      "API-get-block-children",
+      {
+        block_id: blockId,
+      },
+      (response) => response.results
+    );
+  }
+
+  /**
+   * Phase 4: Get block details
+   */
+  async getBlock(blockId: string): Promise<NotionBlock> {
+    return this.callTool<NotionBlock>("API-retrieve-a-block", {
+      block_id: blockId,
+    });
+  }
+
+  /**
+   * Phase 4: Recursively get all blocks in a page
+   */
+  async getAllBlocksRecursive(blockId: string): Promise<NotionBlock[]> {
+    const allBlocks: NotionBlock[] = [];
+    const blocks = await this.getBlockChildren(blockId);
+
+    for (const block of blocks) {
+      allBlocks.push(block);
+
+      // Recursively get children if block has them
+      if (block.has_children) {
+        const childBlocks = await this.getAllBlocksRecursive(block.id);
+        allBlocks.push(...childBlocks);
+      }
+    }
+
+    return allBlocks;
+  }
+
+  /**
+   * Phase 5: Get all comments for a page
+   */
+  async getPageComments(pageId: string): Promise<NotionComment[]> {
+    return this.fetchAllPages<NotionComment>(
+      "API-retrieve-a-comment",
+      {
+        block_id: pageId,
+      },
+      (response) => response.results
+    );
+  }
+
+  /**
+   * Phase 4: Get page property (for large properties)
+   */
+  async getPageProperty(pageId: string, propertyId: string): Promise<any> {
+    return this.fetchAllPages<any>(
+      "API-retrieve-a-page-property",
+      {
+        page_id: pageId,
+        property_id: propertyId,
+      },
+      (response) => response.results
+    );
+  }
+
+  /**
+   * Set custom rate limit delay
+   */
+  setRateLimitDelay(delayMs: number): void {
+    this.rateLimitDelay = delayMs;
+  }
+}

--- a/src/services/indexer/notion/types.ts
+++ b/src/services/indexer/notion/types.ts
@@ -1,0 +1,158 @@
+// Notion entity types for the indexer
+
+export interface NotionUser {
+  object: "user";
+  id: string;
+  type: "person" | "bot";
+  name: string;
+  avatar_url?: string;
+  person?: {
+    email: string;
+  };
+  bot?: {
+    owner: {
+      type: string;
+      workspace?: boolean;
+    };
+    workspace_name?: string;
+  };
+}
+
+export interface NotionPage {
+  object: "page";
+  id: string;
+  created_time: string;
+  last_edited_time: string;
+  created_by: { object: "user"; id: string };
+  last_edited_by: { object: "user"; id: string };
+  cover?: {
+    type: string;
+    [key: string]: any;
+  };
+  icon?: {
+    type: string;
+    [key: string]: any;
+  };
+  parent: {
+    type: string;
+    [key: string]: any;
+  };
+  archived: boolean;
+  properties: Record<string, any>;
+  url: string;
+  public_url?: string;
+}
+
+export interface NotionDatabase {
+  object: "database";
+  id: string;
+  created_time: string;
+  last_edited_time: string;
+  created_by: { object: "user"; id: string };
+  last_edited_by: { object: "user"; id: string };
+  title: Array<{
+    type: string;
+    text: { content: string };
+  }>;
+  description: Array<{
+    type: string;
+    text: { content: string };
+  }>;
+  icon?: {
+    type: string;
+    [key: string]: any;
+  };
+  cover?: {
+    type: string;
+    [key: string]: any;
+  };
+  properties: Record<string, any>;
+  parent: {
+    type: string;
+    [key: string]: any;
+  };
+  url: string;
+  archived: boolean;
+}
+
+export interface NotionBlock {
+  object: "block";
+  id: string;
+  parent: {
+    type: string;
+    [key: string]: any;
+  };
+  created_time: string;
+  last_edited_time: string;
+  created_by: { object: "user"; id: string };
+  last_edited_by: { object: "user"; id: string };
+  has_children: boolean;
+  archived: boolean;
+  type: string;
+  [key: string]: any; // Block type-specific content
+}
+
+export interface NotionComment {
+  object: "comment";
+  id: string;
+  parent: {
+    type: string;
+    [key: string]: any;
+  };
+  discussion_id: string;
+  created_time: string;
+  last_edited_time: string;
+  created_by: { object: "user"; id: string };
+  rich_text: Array<{
+    type: string;
+    text: { content: string };
+    [key: string]: any;
+  }>;
+}
+
+export interface PaginatedResponse<T> {
+  results: T[];
+  next_cursor: string | null;
+  has_more: boolean;
+}
+
+export interface IndexerProgress {
+  job_id: string;
+  started_at: string;
+  status: "running" | "completed" | "failed" | "paused";
+  current_phase: string;
+  progress: {
+    users: { total: number; processed: number };
+    databases: { total: number; processed: number };
+    pages: { total: number; processed: number };
+    blocks: { total: number; processed: number };
+    comments: { total: number; processed: number };
+  };
+  errors: Array<{
+    entity_id: string;
+    entity_type: string;
+    error: string;
+    timestamp: string;
+  }>;
+  last_updated: string;
+}
+
+export interface IndexerOptions {
+  include_comments: boolean;
+  include_archived: boolean;
+  since?: string; // ISO timestamp for incremental sync
+  max_retries: number;
+  rate_limit_delay: number; // milliseconds
+}
+
+export interface IndexerResult {
+  success: boolean;
+  job_id: string;
+  progress: IndexerProgress;
+  summary: {
+    total_entities: number;
+    successful: number;
+    failed: number;
+    duration_ms: number;
+  };
+}

--- a/src/shared/database/mongoose.ts
+++ b/src/shared/database/mongoose.ts
@@ -1,6 +1,7 @@
 import mongoose from "mongoose";
 import { env } from "../../env.js";
 import type { GraphSchema } from "../../types/graph-schema.js";
+import type { MCPServerConfig } from "../../services/connector/mcp-clients/client.js";
 
 export interface MongooseConnection {
   connection: typeof mongoose;
@@ -76,6 +77,41 @@ GraphSchemaSchema.index({ workspaceId: 1 }, { unique: true });
 export const GraphSchemaModel = mongoose.model<GraphSchema>(
   "GraphSchema",
   GraphSchemaSchema
+);
+
+// MCP Server Config Mongoose Schema
+const MCPServerConfigSchema = new mongoose.Schema<MCPServerConfig>(
+  {
+    name: { type: String, required: true, unique: true, index: true },
+    type: { type: String, required: true, enum: ["stdio", "sse"] },
+    command: { type: String },
+    args: [{ type: String }],
+    env: { type: Map, of: String },
+    url: { type: String },
+    headers: { type: Map, of: String },
+  },
+  {
+    collection: "mcp_server_configs",
+    timestamps: true,
+  }
+);
+
+// Create indexes
+MCPServerConfigSchema.index({ name: 1 }, { unique: true });
+
+// Add validation for type-specific required fields
+MCPServerConfigSchema.pre("save", function () {
+  if (this.type === "stdio" && !this.command) {
+    throw new Error("stdio server requires 'command' field");
+  } else if (this.type === "sse" && !this.url) {
+    throw new Error("sse server requires 'url' field");
+  }
+});
+
+// Export the model
+export const MCPServerConfigModel = mongoose.model<MCPServerConfig>(
+  "MCPServerConfig",
+  MCPServerConfigSchema
 );
 
 /**


### PR DESCRIPTION
Add CRUD endpoints for managing MCP server configurations:
- GET /api/mcp-servers - List all server configurations
- POST /api/mcp-servers - Create new configuration with validation
- PUT /api/mcp-servers/:id - Update existing configuration
- DELETE /api/mcp-servers/:id - Delete configuration and disconnect

Changes include:
- Import MCPServerConfig type and MCPServerConfigModel for database operations
- Initialize services before loading proxy configuration
- Auto-connect to newly created servers
- Persist configurations using MongoDB/Mongoose
- Add proper error handling and HTTP status codes (400, 404, 409, 500)

This enables dynamic management of MCP server connections without requiring configuration file changes and server restarts.

sample curl to insert new mcp server config
```sh
curl -X POST http://localhost:3000/api/mcp-servers \
  -H "Content-Type: application/json" \
  -d '{
    "name": "notion",
    "type": "stdio",
    "command": "npx",
    "args": ["-y", "@notionhq/notion-mcp-server"],
    "env": {
      "OPENAPI_MCP_HEADERS": "{\"Authorization\": \"Bearer ntn_YOUR_TOKEN\", \"Notion-Version\": \"2022-06-28\"}"
    }
  }'
```

Script to trigger indexing function
```ts
import { indexMcpServers } from "../src/services/indexer/index.js";
import { initializeServices } from "../src/mcp/initialization.js";

const run = async () => {
  await initializeServices();

  await indexMcpServers();
};

run()
  .then(() => process.exit(0))
  .catch((e) => {
    console.error(e);
    process.exit(1);
  });
```