### PR TITLE
Feature/sync queue

### DIFF
--- a/packages/server/scripts/sync-records.ts
+++ b/packages/server/scripts/sync-records.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { SyncService } from "../src/services/sync/sync.service.js";
+import { syncAllRemoteMcpServers } from "../src/services/sync/sync.service.js";
 import { initializeServices } from "../src/mcp/initialization.js";
 
 /**
@@ -18,8 +18,7 @@ const run = async () => {
   // init db connections and mcp server
   await initializeServices();
 
-  const syncService = new SyncService();
-  await syncService.syncAll();
+  await syncAllRemoteMcpServers();
 
   console.log("\n✨ Record sync completed");
   console.log("\nNext steps:");

--- a/packages/server/src/connections/redis.ts
+++ b/packages/server/src/connections/redis.ts
@@ -6,7 +6,7 @@ export interface RedisConnection {
   close: () => Promise<void>;
 }
 
-const createRedisOptions = (): RedisOptions => {
+export const createRedisOptions = (): RedisOptions => {
   return {
     host: env.REDIS_HOST,
     port: parseInt(env.REDIS_PORT),

--- a/packages/server/src/mcp/initialization.ts
+++ b/packages/server/src/mcp/initialization.ts
@@ -125,6 +125,7 @@ export async function initializeServices(): Promise<ServiceConnections> {
     connectMcpServers(),
   ]);
 
+  // start the bullmq workers. Don't wait for them, otherwise it'll hang
   initWorkers().catch((e) => console.error(e));
 
   return services;

--- a/packages/server/src/mcp/initialization.ts
+++ b/packages/server/src/mcp/initialization.ts
@@ -15,6 +15,8 @@ import { connectRedis, RedisConnection } from "../connections/redis.js";
 import { resolveSerializedZodOutput } from "../utils/resolveSerializedZodOutput.js";
 import { mcpClientManager, MCPServerConfig } from "./client.js";
 import { loadProxyConfig } from "./config-loader.js";
+import { initWorkers } from "../services/queue/index.js";
+import { VectorStore } from "../stores/vector.store.js";
 
 export async function initializeRemoteServers(
   configs: MCPServerConfig[],
@@ -115,7 +117,15 @@ export async function initializeServices(): Promise<ServiceConnections> {
   services = { mongoose, qdrant, memgraph, redis };
   console.error("✅ All services initialized successfully!");
 
-  await connectMcpServers();
+  const vectorStore = new VectorStore(qdrant);
+
+  await Promise.all([
+    // Ensure Qdrant collection exists
+    vectorStore.ensureCollection(),
+    connectMcpServers(),
+  ]);
+
+  initWorkers().catch((e) => console.error(e));
 
   return services;
 }
@@ -126,6 +136,7 @@ export async function shutdownServices(): Promise<void> {
       services.qdrant.close(),
       services.memgraph.close(),
       services.redis.close(),
+      services.mongoose.close(),
     ]);
   }
 }

--- a/packages/server/src/models/mcp-config.model.ts
+++ b/packages/server/src/models/mcp-config.model.ts
@@ -1,9 +1,16 @@
 import mongoose, { InferSchemaType } from "mongoose";
+import { SourceType } from "../types/index.js";
 
 // MCP Server Config Mongoose Schema
 const MCPServerConfigSchema = new mongoose.Schema(
   {
-    name: { type: String, required: true, unique: true, index: true },
+    name: {
+      type: String,
+      required: true,
+      unique: true,
+      index: true,
+      enum: ["notion", "slack", "calendar", "jira"] satisfies SourceType[],
+    },
     type: { type: String, required: true, enum: ["stdio", "sse"] },
     command: { type: String },
     args: [{ type: String }],

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -11,6 +11,7 @@ import {
   shutdownServices,
 } from "./mcp/initialization.js";
 import { MCPServerConfigModel } from "./models/mcp-config.model.js";
+import { syncMcpServerQueue } from "./services/queue/sync.queue.js";
 
 // Start server
 const runServer = async () => {
@@ -312,6 +313,37 @@ const runServer = async () => {
 
     await mcpServer.connect(transport);
     await transport.handleRequest(req, res, req.body);
+  });
+
+  app.post("/api/sync/:configId", async (req: Request, res: Response) => {
+    try {
+      const config = await MCPServerConfigModel.findById(req.params.configId);
+
+      if (!config) {
+        res.status(404).json({
+          success: false,
+          error: "MCP server config not found",
+        });
+        return;
+      }
+
+      if (!mcpClientManager.isConnected(config.name)) {
+        res.status(400).json({ success: false, error: "Server not connected" });
+        return;
+      }
+
+      // Queue sync job
+      await syncMcpServerQueue.add(config._id.toString(), {
+        mcpConfig: config.toObject(),
+      });
+
+      res.status(200).json({ success: true });
+    } catch (error) {
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   });
 
   // 404 for other routes

--- a/packages/server/src/services/indexing/embeddings/vector-indexer.service.ts
+++ b/packages/server/src/services/indexing/embeddings/vector-indexer.service.ts
@@ -43,9 +43,6 @@ export async function insertAllRecordsToVectorDB(
     `   Concurrency: ${env.VECTOR_INDEXING_CONCURRENCY} parallel records`
   );
 
-  // Ensure Qdrant collection exists
-  await vectorStore.ensureCollection();
-
   let skip = 0;
   let hasMore = true;
   let batchNumber = 0;

--- a/packages/server/src/services/queue/config.ts
+++ b/packages/server/src/services/queue/config.ts
@@ -1,0 +1,15 @@
+import { ConnectionOptions } from "bullmq";
+import { createRedisOptions } from "../../connections/redis.js";
+
+export enum QUEUE_NAME {
+  SYNC_MCP_SERVER = "SYNC_MCP_SERVER",
+  INDEX_VECTOR = "INDEX_VECTOR",
+  INDEX_GRAPH = "INDEX_GRAPH",
+}
+
+export const createRedisConnection = (): ConnectionOptions => {
+  return {
+    ...createRedisOptions(),
+    maxRetriesPerRequest: null, // Required for BullMQ
+  };
+};

--- a/packages/server/src/services/queue/index-graph.queue.ts
+++ b/packages/server/src/services/queue/index-graph.queue.ts
@@ -1,0 +1,100 @@
+import { Processor, Queue, Worker } from "bullmq";
+
+import { initializeServices } from "../../mcp/initialization.js";
+import { GraphStore } from "../../stores/graph.store.js";
+import { RecordStore } from "../../stores/record.store.js";
+import { SourceType } from "../../types/index.js";
+import { GraphIndexerService } from "../indexing/graph/graph-indexer.service.js";
+import { NotionMCPClient } from "../sources/notion/mcpClient.js";
+import { BaseRecordAdapter } from "../sync/adapters/base-adapter.js";
+import { NotionAdapter } from "../sync/adapters/notion-adapter.js";
+import { createRedisConnection, QUEUE_NAME } from "./config.js";
+
+const processor: Processor<
+  IndexGraphJobData,
+  IndexGraphJobResult,
+  string
+> = async ({ data: { source } }) => {
+  // Initialize services
+  const { memgraph } = await initializeServices();
+
+  // Create stores
+  const recordStore = new RecordStore();
+  const graphStore = new GraphStore(memgraph);
+
+  const adapters = new Map<SourceType, BaseRecordAdapter>();
+
+  if (source === "notion") {
+    const notionClient = new NotionMCPClient();
+    adapters.set("notion", new NotionAdapter(notionClient));
+  }
+
+  const graphIndexer = new GraphIndexerService(
+    recordStore,
+    graphStore,
+    adapters
+  );
+
+  await graphIndexer.indexAll(source);
+};
+
+type IndexGraphJobData = {
+  source: SourceType;
+};
+
+type IndexGraphJobResult = void;
+
+export const indexGraphWorker = new Worker<
+  IndexGraphJobData,
+  IndexGraphJobResult
+>(QUEUE_NAME.INDEX_GRAPH, processor, {
+  connection: createRedisConnection(),
+  concurrency: 2,
+  autorun: false,
+});
+
+// Set up worker event handlers
+indexGraphWorker.on("completed", (job) => {
+  console.log(
+    `✅ Graph index job completed: ${job.id} for record ${job.data.source}`
+  );
+});
+
+indexGraphWorker.on("failed", (job, err) => {
+  console.error(
+    `❌ Graph index job failed: ${job?.id} for record ${job?.data.source}`,
+    err
+  );
+});
+
+indexGraphWorker.on("error", (err) => {
+  console.error("Graph index worker error:", err);
+});
+
+indexGraphWorker.on("active", (job) => {
+  console.log(
+    `🔄 Graph index job started: ${job.id} for record ${job.data.source}`
+  );
+});
+
+export const indexGraphQueue = new Queue<
+  IndexGraphJobData,
+  IndexGraphJobResult
+>(QUEUE_NAME.INDEX_GRAPH, {
+  connection: createRedisConnection(),
+  defaultJobOptions: {
+    attempts: 3,
+    backoff: {
+      type: "exponential",
+      delay: 5000,
+    },
+    removeOnComplete: {
+      count: 100, // Keep last 100 completed jobs
+      age: 24 * 60 * 60, // Keep for 24 hours
+    },
+    removeOnFail: {
+      count: 500, // Keep last 500 failed jobs for debugging
+      age: 7 * 24 * 60 * 60, // Keep for 7 days
+    },
+  },
+});

--- a/packages/server/src/services/queue/index-vector.queue.ts
+++ b/packages/server/src/services/queue/index-vector.queue.ts
@@ -1,0 +1,67 @@
+import { Processor, Queue, Worker } from "bullmq";
+
+import { insertAllRecordsToVectorDB } from "../indexing/embeddings/vector-indexer.service.js";
+import { RecordStore } from "../../stores/record.store.js";
+import { VectorStore } from "../../stores/vector.store.js";
+import { initializeServices } from "../../mcp/initialization.js";
+import { createRedisConnection, QUEUE_NAME } from "./config.js";
+import { SourceType } from "../../types/index.js";
+
+const processor: Processor<
+  IndexVectorJobData,
+  IndexVectorJobResult,
+  string
+> = async ({ data: { source } }) => {
+  // Initialize services
+  const { qdrant } = await initializeServices();
+
+  // Create stores
+  const recordStore = new RecordStore();
+  const vectorStore = new VectorStore(qdrant);
+
+  await insertAllRecordsToVectorDB(recordStore, vectorStore, source);
+};
+
+type IndexVectorJobData = {
+  source: SourceType;
+};
+
+type IndexVectorJobResult = void;
+
+export const indexVectorWorker = new Worker<
+  IndexVectorJobData,
+  IndexVectorJobResult
+>(QUEUE_NAME.INDEX_VECTOR, processor, {
+  connection: createRedisConnection(),
+  concurrency: 2,
+  autorun: false,
+});
+
+// Set up worker event handlers
+indexVectorWorker.on("completed", (job) => {
+  console.log(
+    `✅ Vector index job completed: ${job.id} for ${job.data.source}`
+  );
+});
+
+indexVectorWorker.on("failed", (job, err) => {
+  console.error(
+    `❌ Vector index job failed: ${job?.id} for ${job?.data.source}`,
+    err
+  );
+});
+
+indexVectorWorker.on("error", (err) => {
+  console.error("Vector index worker error:", err);
+});
+
+indexVectorWorker.on("active", (job) => {
+  console.log(`🔄 Vector index job started: ${job.id} for ${job.data.source}`);
+});
+
+export const indexVectorQueue = new Queue<
+  IndexVectorJobData,
+  IndexVectorJobResult
+>(QUEUE_NAME.INDEX_VECTOR, {
+  connection: createRedisConnection(),
+});

--- a/packages/server/src/services/queue/index.ts
+++ b/packages/server/src/services/queue/index.ts
@@ -1,0 +1,16 @@
+import { Worker } from "bullmq";
+
+import { indexGraphWorker } from "./index-graph.queue.js";
+import { indexVectorWorker } from "./index-vector.queue.js";
+import { syncMcpServerWorker } from "./sync.queue.js";
+import { QUEUE_NAME } from "./config.js";
+
+const workerMap: Record<QUEUE_NAME, Worker> = {
+  [QUEUE_NAME.SYNC_MCP_SERVER]: syncMcpServerWorker,
+  [QUEUE_NAME.INDEX_VECTOR]: indexVectorWorker,
+  [QUEUE_NAME.INDEX_GRAPH]: indexGraphWorker,
+};
+
+export const initWorkers = async () => {
+  await Promise.all(Object.values(workerMap).map((worker) => worker.run()));
+};

--- a/packages/server/src/services/queue/sync.queue.ts
+++ b/packages/server/src/services/queue/sync.queue.ts
@@ -1,0 +1,69 @@
+import { Processor, Queue, Worker } from "bullmq";
+
+import { MCPServerConfig } from "../../models/mcp-config.model.js";
+import { syncMcpServer } from "../sync/sync.service.js";
+import { indexGraphQueue } from "./index-graph.queue.js";
+import { indexVectorQueue } from "./index-vector.queue.js";
+import { createRedisConnection, QUEUE_NAME } from "./config.js";
+
+const processor: Processor<
+  SyncMcpServerJobData,
+  SyncMcpServerJobResult,
+  string
+> = async ({ data: { mcpConfig } }) => {
+  await syncMcpServer(mcpConfig);
+
+  await Promise.all([
+    indexVectorQueue.add(mcpConfig.name, {
+      source: mcpConfig.name,
+    }),
+    indexGraphQueue.add(mcpConfig.name, {
+      source: mcpConfig.name,
+    }),
+  ]);
+  return;
+};
+
+type SyncMcpServerJobData = {
+  mcpConfig: MCPServerConfig;
+};
+
+type SyncMcpServerJobResult = void;
+
+export const syncMcpServerWorker = new Worker<
+  SyncMcpServerJobData,
+  SyncMcpServerJobResult
+>(QUEUE_NAME.SYNC_MCP_SERVER, processor, {
+  connection: createRedisConnection(),
+  concurrency: 2,
+  autorun: false,
+});
+
+// Set up worker event handlers
+syncMcpServerWorker.on("completed", (job) => {
+  console.log(
+    `✅ Sync job completed: ${job.id} for ${job.data.mcpConfig.name}`
+  );
+});
+
+syncMcpServerWorker.on("failed", (job, err) => {
+  console.error(
+    `❌ Sync job failed: ${job?.id} for ${job?.data.mcpConfig.name}`,
+    err
+  );
+});
+
+syncMcpServerWorker.on("error", (err) => {
+  console.error("Worker error:", err);
+});
+
+syncMcpServerWorker.on("active", (job) => {
+  console.log(`🔄 Sync job started: ${job.id} for ${job.data.mcpConfig.name}`);
+});
+
+export const syncMcpServerQueue = new Queue<
+  SyncMcpServerJobData,
+  SyncMcpServerJobResult
+>(QUEUE_NAME.SYNC_MCP_SERVER, {
+  connection: createRedisConnection(),
+});

--- a/packages/server/src/services/sync/sync.service.ts
+++ b/packages/server/src/services/sync/sync.service.ts
@@ -2,35 +2,29 @@ import { loadProxyConfig } from "../../mcp/config-loader.js";
 import { RecordStore } from "../../stores/record.store.js";
 import { NotionMCPClient } from "../sources/notion/mcpClient.js";
 import { NotionAdapter } from "./adapters/notion-adapter.js";
-import { connectMongoose } from "../../connections/mongoose.js";
 import { syncAllRecords } from "./record-sync.service.js";
 
-/**
- * Sync Service
- * Handles syncing records from external sources to MongoDB
- */
-export class SyncService {
-  /**
-   * Sync records from all configured sources to MongoDB
-   */
-  async syncAll(): Promise<void> {
-    // Connect to MongoDB before any database operations
-    await connectMongoose();
+import { MCPServerConfig } from "../../models/mcp-config.model.js";
 
-    const validConfigs = await loadProxyConfig();
+export const syncMcpServer = async (mcpConfig: MCPServerConfig) => {
+  const recordStore = new RecordStore();
 
-    await Promise.all(
-      validConfigs.map(async (config) => {
-        const recordStore = new RecordStore();
+  if (mcpConfig.name === "notion") {
+    const notionClient = new NotionMCPClient();
+    const notionAdapter = new NotionAdapter(notionClient);
+    await syncAllRecords(recordStore, "notion", notionAdapter);
 
-        if (config.name === "notion") {
-          const notionClient = new NotionMCPClient();
-          const notionAdapter = new NotionAdapter(notionClient);
-          await syncAllRecords(recordStore, "notion", notionAdapter);
-
-          console.log("✅ Saved records into document DB");
-        }
-      })
-    );
+    console.log("✅ Saved records into document DB");
   }
+};
+
+/**
+ * Sync records from all configured sources to MongoDB (direct execution)
+ * This bypasses the queue and runs synchronously - useful for testing or single-run scripts
+ * @deprecated Use queueAllRemoteMcpServers() with the worker for production
+ */
+export async function syncAllRemoteMcpServers(): Promise<void> {
+  const validConfigs = await loadProxyConfig();
+
+  await Promise.all(validConfigs.map(syncMcpServer));
 }

--- a/packages/server/src/stores/vector.store.ts
+++ b/packages/server/src/stores/vector.store.ts
@@ -62,9 +62,6 @@ export class VectorStore {
   async upsertPoints(points: VectorPoint[]): Promise<void> {
     if (points.length === 0) return;
 
-    // Ensure collection exists before upserting
-    await this.ensureCollection();
-
     await this.qdrant.client.upsert(this.collectionName, {
       wait: true,
       points: points.map((p) => ({


### PR DESCRIPTION
- Replace SyncService class instantiation with functional syncAllRemoteMcpServers()
- Move vector store collection initialization and worker startup to initializeServices()
- Add queue-based endpoint for triggering MCP server sync
- Export createRedisOptions for reuse in queue workers
- Add enum validation for MCP server config names (notion, slack, calendar, jira)
- Add mongoose.close() to shutdown services for proper cleanup
- Remove redundant ensureCollection() call from vector indexer service

This refactor introduces async queue processing for syncing MCP servers,
centralizes initialization logic, and improves type safety and resource management.