### PR TITLE
chore: adds vector index check

### DIFF
--- a/packages/server/src/services/indexing/embeddings/vector-indexer.service.ts
+++ b/packages/server/src/services/indexing/embeddings/vector-indexer.service.ts
@@ -60,13 +60,20 @@ export async function insertAllRecordsToVectorDB(
       break;
     }
 
+    // LastEmbedDate will be empty if never indexed, we will index it
+    // If source is updated and lastEmbedDate is older, we will re-index it
+    const recordsToProcess = records.filter((record) => {
+      if (!record.lastEmbedDate) return true;
+      return record.sourceUpdatedAt.getTime() > record.lastEmbedDate.getTime();
+    });
+
     batchNumber++;
     console.log(
       `\n🔄 Processing batch ${batchNumber} (${records.length} records)...`
     );
 
     // Process batch in parallel
-    const promises = records.map((record) =>
+    const promises = recordsToProcess.map((record) =>
       limit(async () => {
         try {
           const vectorIds = await insertRecordToVectorDB(


### PR DESCRIPTION
## Reason for this change
- Currently, if we click `sync` button on UI then there will be new duplicate entries created in the DB

## Fix

In records, we have following things
- Whenever we update something in notion, it gives us new sourceUpdatedAt (which we take from notion in transformation function)
- So if user updates the notion then we need to re-index it and we will compare it with lastEmbedDate (which we save whenever we upsert embedding)

