### PR TITLE
feat(server): refactor graph embedding metadata schema and type defin…

### DIFF
--- a/packages/server/src/models/graph-embedding-metadata.model.ts
+++ b/packages/server/src/models/graph-embedding-metadata.model.ts
@@ -1,4 +1,4 @@
-import { Schema, model } from "mongoose";
+import { InferSchemaType, Schema, model } from "mongoose";
 
 /**
  * Tracks embedding metadata for graph elements (entities and relationships)
@@ -9,52 +9,8 @@ import { Schema, model } from "mongoose";
  * Represents a single mention of a relationship in a document
  * Used to track provenance: which documents mention which relationships
  */
-export interface IRelationshipMention {
-  documentId: string; // MongoDB record ID that mentions this relationship
-  confidence: number; // Extraction confidence (0.0-1.0)
-  extractedAt: Date; // When this mention was extracted
-}
 
-export interface IGraphEmbeddingMetadata {
-  _id: string; // Format: "entity_{globalId}" or "rel_{sourceId}_{type}_{targetId}" - Semantic MongoDB ID
-  qdrantId?: string; // UUID for Qdrant point ID (required by Qdrant, generated on first embedding)
-  itemType: "entity" | "relationship";
-
-  // For entities
-  entityId?: string; // Global Memgraph entity ID
-  entityType?: string; // "Person", "Organization", etc.
-  entityDescription?: string; // LLM-extracted entity description
-
-  // For relationships
-  sourceId?: string; // Global source entity ID
-  targetId?: string; // Global target entity ID
-  relType?: string; // "WORKS_WITH", "REPORTS_TO", etc.
-  relationshipDescription?: string; // LLM-extracted relationship description
-
-  // Source tracking
-  source?: string; // Primary source ("notion", "github", etc.)
-  sources?: string[]; // All sources that contributed to this element
-
-  // Embedding tracking
-  contentChecksum: string; // Current content hash for change detection
-  embeddedChecksum?: string; // Checksum when last embedded (for comparison)
-  embeddedAt?: Date; // When last embedded
-  embeddingModelVersion?: string; // Which model was used
-
-  // Provenance - which documents contributed to this element
-  sourceDocumentIds: string[]; // Array of MongoDB record IDs
-  lastUpdatedBy: string; // Which document triggered the last update
-
-  // NEW: Relationship mentions tracking (for relationships only)
-  // Tracks which documents mention this relationship and with what confidence
-  // Used for orphan detection: relationships with empty array can be deleted
-  mentionedInDocuments?: IRelationshipMention[];
-
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-const graphEmbeddingMetadataSchema = new Schema<IGraphEmbeddingMetadata>(
+const graphEmbeddingMetadataSchema = new Schema(
   {
     _id: {
       type: String,
@@ -65,6 +21,10 @@ const graphEmbeddingMetadataSchema = new Schema<IGraphEmbeddingMetadata>(
       index: true,
       sparse: true,
     },
+    memgraphId: {
+      type: String,
+      index: true,
+    },
     itemType: {
       type: String,
       required: true,
@@ -73,11 +33,6 @@ const graphEmbeddingMetadataSchema = new Schema<IGraphEmbeddingMetadata>(
     },
 
     // Entity fields
-    entityId: {
-      type: String,
-      index: true,
-      sparse: true,
-    },
     entityType: {
       type: String,
       sparse: true,
@@ -108,11 +63,6 @@ const graphEmbeddingMetadataSchema = new Schema<IGraphEmbeddingMetadata>(
     },
 
     // Source tracking
-    source: {
-      type: String,
-      index: true,
-      sparse: true,
-    },
     sources: {
       type: [String],
       default: [],
@@ -201,7 +151,11 @@ graphEmbeddingMetadataSchema.index({
   mentionedInDocuments: 1,
 }); // Find orphaned relationships (empty array)
 
-export const GraphEmbeddingMetadata = model<IGraphEmbeddingMetadata>(
+export type GraphEmbeddingMetadataSchema = InferSchemaType<
+  typeof graphEmbeddingMetadataSchema
+>;
+
+export const GraphEmbeddingMetadata = model<GraphEmbeddingMetadataSchema>(
   "GraphEmbeddingMetadata",
   graphEmbeddingMetadataSchema
 );

--- a/packages/server/src/services/indexing/embeddings/vector-indexer.service.ts
+++ b/packages/server/src/services/indexing/embeddings/vector-indexer.service.ts
@@ -162,7 +162,7 @@ export async function insertRecordToVectorDB(
       vector: embeddings[index],
       payload: {
         // Link to MongoDB (required)
-        mongoId: record._id,
+        recordId: record._id,
         // Change detection (for re-indexing)
         checksum: record.checksum,
         // Chunk metadata (for result assembly)

--- a/packages/server/src/services/indexing/graph/entity-conflict-resolution.ts
+++ b/packages/server/src/services/indexing/graph/entity-conflict-resolution.ts
@@ -1,6 +1,8 @@
-import { GraphEmbeddingMetadata } from "../../../models/graph-embedding-metadata.model.js";
+import {
+  GraphEmbeddingMetadata,
+  GraphEmbeddingMetadataSchema,
+} from "../../../models/graph-embedding-metadata.model.js";
 import { RecordStore } from "../../../stores/record.store.js";
-import logger from "../../../utils/logger.js";
 
 /**
  * Conflict resolution strategies for entities that appear in multiple documents
@@ -10,53 +12,36 @@ import logger from "../../../utils/logger.js";
  * Get the best description for an entity from multiple source documents
  * Uses LLM-extracted entity description stored in metadata
  */
-export async function getEntityEmbeddingText(
-  entityId: string,
-  entityType: string,
-  recordStore: RecordStore
-): Promise<string> {
-  // Check if we have metadata for this entity
-  const metadata = await GraphEmbeddingMetadata.findById(entityId);
-
-  if (!metadata) {
-    // No metadata yet - this is a new entity
-    return `${entityType} - ${entityId}\nNo description available`;
-  }
-
+export function getEntityEmbeddingText(
+  metadata: GraphEmbeddingMetadataSchema
+): string {
   // Use LLM-extracted description from metadata
   const description = metadata.entityDescription || "No description available";
 
   // Format: "EntityType - EntityID\nDescription"
-  return `${entityType} - ${entityId}\n${description}`;
+  return `${metadata.entityType} - ${metadata.memgraphId}\n${description}`;
 }
 
 /**
  * Get the best description for a relationship from multiple source documents
  * Uses LLM-extracted relationship description stored in metadata
  */
-export async function getRelationshipEmbeddingText(
-  rel: {
-    sourceId: string;
-    targetId: string;
-    type: string;
-    confidence: number;
-  },
-  recordStore: RecordStore
-): Promise<string> {
-  // Get relationship metadata
-  const relId = `rel_${rel.sourceId}_${rel.type}_${rel.targetId}`;
-  const relMetadata = await GraphEmbeddingMetadata.findById(relId);
-
+export async function getRelationshipEmbeddingText(rel: {
+  relMetadata: GraphEmbeddingMetadataSchema;
+  sourceId: string;
+  targetId: string;
+  type: string;
+}): Promise<string> {
   // Try to get entity names from their metadata
   const sourceMetadata = await GraphEmbeddingMetadata.findById(rel.sourceId);
   const targetMetadata = await GraphEmbeddingMetadata.findById(rel.targetId);
 
-  const sourceName = sourceMetadata?.entityId || "Unknown";
-  const targetName = targetMetadata?.entityId || "Unknown";
+  const sourceName = sourceMetadata?.memgraphId || "Unknown";
+  const targetName = targetMetadata?.memgraphId || "Unknown";
 
   // Use LLM-extracted description from metadata
   const description =
-    relMetadata?.relationshipDescription || "No description available";
+    rel.relMetadata.relationshipDescription || "No description available";
 
   // Format: "SourceEntity -[RelationType]-> TargetEntity\nDescription"
   // Note: Confidence is NOT included in embedding text to avoid re-embedding when confidence changes
@@ -68,12 +53,8 @@ export async function getRelationshipEmbeddingText(
  * Checks if the content checksum has changed or if it hasn't been embedded yet
  */
 export async function shouldReembedEntity(
-  entityId: string,
-  contentChecksum: string,
-  documentId: string
+  metadata: GraphEmbeddingMetadataSchema
 ): Promise<boolean> {
-  const metadata = await GraphEmbeddingMetadata.findById(entityId);
-
   if (!metadata) {
     // No metadata - needs embedding
     return true;
@@ -86,12 +67,6 @@ export async function shouldReembedEntity(
 
   // Check if content checksum differs from embedded checksum
   if (metadata.contentChecksum !== metadata.embeddedChecksum) {
-    return true;
-  }
-
-  // Check if this is a new document mentioning the entity
-  if (!metadata.sourceDocumentIds.includes(documentId)) {
-    // New document - might have new information
     return true;
   }
 

--- a/packages/server/src/services/indexing/graph/graph-embeddings.ts
+++ b/packages/server/src/services/indexing/graph/graph-embeddings.ts
@@ -13,7 +13,6 @@ import { computeChecksum } from "../../../utils/checksum.js";
 import {
   getEntityEmbeddingText,
   getRelationshipEmbeddingText,
-  shouldReembedEntity,
   shouldReembedRelationship,
 } from "./entity-conflict-resolution.js";
 import { env } from "../../../env.js";
@@ -43,7 +42,7 @@ export async function indexEntityEmbeddings(
   // Query MongoDB directly for entities that need embedding (MUCH faster than Memgraph!)
   const entityMetadata = await GraphEmbeddingMetadata.find({
     itemType: "entity",
-    source: source,
+    "sources.0": source, // the 1st source is the primary one
   });
 
   if (entityMetadata.length === 0) {
@@ -51,31 +50,16 @@ export async function indexEntityEmbeddings(
     return stats;
   }
 
-  // Convert metadata to the format we need
-  // Use the first MongoDB document ID as the primary entity ID
-  const globalEntities = entityMetadata.map((meta) => ({
-    memgraphEntityId: meta.entityId!, // Keep for graph operations
-    mongoId: meta.sourceDocumentIds[0], // Use first MongoDB ID as primary
-    type: meta.entityType!,
-    documentIds: meta.sourceDocumentIds,
-  }));
-
   // Filter entities that need embedding
-  const entitiesToEmbed: typeof globalEntities = [];
+  const entitiesToEmbed: typeof entityMetadata = [];
 
-  for (const entity of globalEntities) {
-    const entityText = await getEntityEmbeddingText(
-      entity.memgraphEntityId,
-      entity.type,
-      deps.recordStore
-    );
-    const contentChecksum = computeChecksum(entityText);
-
-    const needsEmbedding = await shouldReembedEntity(
-      entity.mongoId, // Use MongoDB ID for tracking
-      contentChecksum,
-      entity.mongoId
-    );
+  for (const entity of entityMetadata) {
+    // TODO: always re-embed for now.
+    const needsEmbedding = true;
+    // const needsEmbedding = await shouldReembedEntity(
+    //   entity._id,
+    //   entity.recordId
+    // );
 
     if (needsEmbedding) {
       entitiesToEmbed.push(entity);
@@ -87,10 +71,6 @@ export async function indexEntityEmbeddings(
   if (entitiesToEmbed.length === 0) {
     return stats;
   }
-
-  // Get node degrees for all entities using Memgraph IDs
-  const nodeIds = entitiesToEmbed.map((e) => e.memgraphEntityId);
-  const degreeCounts = await deps.graphStore.getNodeRelationshipCounts(nodeIds);
 
   // Process in batches
   for (let i = 0; i < entitiesToEmbed.length; i += BATCH_SIZE) {
@@ -104,27 +84,14 @@ export async function indexEntityEmbeddings(
 
     try {
       // Create entity texts for embedding using Memgraph IDs
-      const entityTexts = await Promise.all(
-        batch.map((entity) =>
-          getEntityEmbeddingText(
-            entity.memgraphEntityId,
-            entity.type,
-            deps.recordStore
-          )
-        )
-      );
+      const entityTexts = batch.map((entity) => getEntityEmbeddingText(entity));
 
       // Generate embeddings
       const embeddings = await embed(entityTexts);
 
-      // Get or create qdrantIds for each entity using MongoDB ID
-      const metadataRecords = await Promise.all(
-        batch.map((entity) => GraphEmbeddingMetadata.findById(entity.mongoId))
-      );
-
       // Create vector points with UUIDs
       const points = batch.map((entity, index) => {
-        const existingQdrantId = metadataRecords[index]?.qdrantId;
+        const existingQdrantId = entity.qdrantId;
         const qdrantId = existingQdrantId || randomUUID();
 
         return {
@@ -132,13 +99,10 @@ export async function indexEntityEmbeddings(
           vector: embeddings[index],
           payload: {
             type: "entity" as const,
-            entityId: entity.memgraphEntityId, // Store MongoDB ID for direct lookup
-            entityType: entity.type,
-            mongoId: entity.mongoId,
+            graphEmbeddingMetadataId: entity._id,
             source: source,
-            degree: degreeCounts.get(entity.memgraphEntityId) || 0,
             checksum: computeChecksum(entityTexts[index]),
-          } as EntityVectorPayload,
+          } satisfies EntityVectorPayload,
         };
       });
 
@@ -152,24 +116,19 @@ export async function indexEntityEmbeddings(
         const embeddedChecksum = computeChecksum(entityTexts[j]);
         const qdrantId = points[j].id;
 
-        await GraphEmbeddingMetadata.findOneAndUpdate(
-          { _id: entity.memgraphEntityId }, // Use memgraphEntityIdas the primary key
+        // await entity.save({});
+
+        await GraphEmbeddingMetadata.updateOne(
+          { memgraphId: entity.memgraphId },
           {
             $set: {
               itemType: "entity",
-              entityId: entity.memgraphEntityId, // Keep Memgraph ID for reference
-              entityType: entity.type,
               qdrantId: qdrantId,
               embeddedChecksum: embeddedChecksum,
               embeddedAt: new Date(),
               embeddingModelVersion: env.LLM_EMBEDDING_MODEL,
-              lastUpdatedBy: entity.documentIds[entity.documentIds.length - 1],
             },
-            $addToSet: {
-              sourceDocumentIds: { $each: entity.documentIds },
-            },
-          },
-          { upsert: true }
+          }
         );
       }
     } catch (err) {
@@ -211,7 +170,7 @@ export async function indexRelationshipEmbeddings(
   // Query MongoDB directly for relationships that need embedding (MUCH faster than Memgraph!)
   const relMetadata = await GraphEmbeddingMetadata.find({
     itemType: "relationship",
-    source: source,
+    "sources.0": source, // the 1st source is the primary one
   });
 
   if (relMetadata.length === 0) {
@@ -239,19 +198,19 @@ export async function indexRelationshipEmbeddings(
   // Create mapping from Memgraph entity ID to MongoDB document ID
   const entityIdToMongoId = new Map<string, string>();
   entityMetadata.forEach((meta) => {
-    if (meta.entityId && meta.sourceDocumentIds.length > 0) {
-      entityIdToMongoId.set(meta.entityId, meta.sourceDocumentIds[0]);
+    if (meta.memgraphId && meta.sourceDocumentIds.length > 0) {
+      entityIdToMongoId.set(meta.memgraphId, meta.sourceDocumentIds[0]);
     }
   });
 
   // Convert metadata to the format we need with MongoDB IDs
   const relationships = relMetadata
     .map((meta) => {
-      const sourceMongoId = entityIdToMongoId.get(meta.sourceId!);
-      const targetMongoId = entityIdToMongoId.get(meta.targetId!);
+      const sourceRecordId = entityIdToMongoId.get(meta.sourceId!);
+      const targetRecordId = entityIdToMongoId.get(meta.targetId!);
 
       // Skip relationships where we can't map to MongoDB IDs
-      if (!sourceMongoId || !targetMongoId) {
+      if (!sourceRecordId || !targetRecordId) {
         logger.warn(
           `Skipping relationship ${meta.sourceId} -> ${meta.targetId}: Cannot map to MongoDB IDs`
         );
@@ -259,12 +218,10 @@ export async function indexRelationshipEmbeddings(
       }
 
       return {
-        memgraphSourceId: meta.sourceId!,
-        memgraphTargetId: meta.targetId!,
-        sourceId: sourceMongoId,
-        targetId: targetMongoId,
-        type: meta.relType!,
-        confidence: 1.0,
+        ...meta,
+        sourceRecordId,
+        targetRecordId,
+        confidence: 1.0, // TODO: is it ok to hardcode?
       };
     })
     .filter((r): r is NonNullable<typeof r> => r !== null);
@@ -277,21 +234,23 @@ export async function indexRelationshipEmbeddings(
   const relsToEmbed: typeof relationships = [];
 
   for (const rel of relationships) {
-    const relId = `rel_${rel.sourceId}_${rel.type}_${rel.targetId}`;
-    // Use Memgraph IDs for getting the embedding text
-    const relForText = {
-      sourceId: rel.memgraphSourceId,
-      targetId: rel.memgraphTargetId,
-      type: rel.type,
-      confidence: rel.confidence,
-    };
-    const relText = await getRelationshipEmbeddingText(
-      relForText,
-      deps.recordStore
-    );
-    const checksum = computeChecksum(relText);
+    // TODO: always re-embed for now.
+    const needsEmbedding = true;
+    // const relId = `rel_${rel.sourceRecordId}_${rel.type}_${rel.targetRecordId}`;
+    // // Use Memgraph IDs for getting the embedding text
+    // const relForText = {
+    //   sourceId: rel.sourceMemgraphId,
+    //   targetId: rel.targetMemgraphId,
+    //   type: rel.type,
+    //   confidence: rel.confidence,
+    // };
+    // const relText = await getRelationshipEmbeddingText(
+    //   relForText,
+    //   deps.recordStore
+    // );
+    // const checksum = computeChecksum(relText);
 
-    const needsEmbedding = await shouldReembedRelationship(relId, checksum);
+    // const needsEmbedding = await shouldReembedRelationship(relId, checksum);
 
     if (needsEmbedding) {
       relsToEmbed.push(rel);
@@ -322,43 +281,34 @@ export async function indexRelationshipEmbeddings(
       // Create relationship texts for embedding using Memgraph IDs
       const relTexts = await Promise.all(
         batch.map((rel) => {
-          const relForText = {
-            sourceId: rel.memgraphSourceId,
-            targetId: rel.memgraphTargetId,
-            type: rel.type,
-            confidence: rel.confidence,
-          };
-          return getRelationshipEmbeddingText(relForText, deps.recordStore);
+          return getRelationshipEmbeddingText({
+            relMetadata: rel,
+            sourceId: rel.sourceId!,
+            targetId: rel.targetId!,
+            type: rel.relType!,
+          });
         })
       );
 
       // Generate embeddings
       const embeddings = await embed(relTexts);
 
-      // Get or create qdrantIds for each relationship using MongoDB IDs
-      const relIds = batch.map(
-        (rel) => `rel_${rel.sourceId}_${rel.type}_${rel.targetId}`
-      );
-      const metadataRecords = await Promise.all(
-        relIds.map((relId) => GraphEmbeddingMetadata.findById(relId))
-      );
-
       // Create vector points with UUIDs
       const points = batch.map((rel, index) => {
-        const existingQdrantId = metadataRecords[index]?.qdrantId;
+        const existingQdrantId = rel.qdrantId;
         const qdrantId = existingQdrantId || randomUUID();
 
         return {
           id: qdrantId,
           vector: embeddings[index],
           payload: {
-            type: "relationship" as const,
-            sourceId: rel.sourceId, // MongoDB ID
-            targetId: rel.targetId, // MongoDB ID
-            relType: rel.type,
+            type: "relationship",
+            sourceId: rel.sourceRecordId, // MongoDB ID
+            targetId: rel.targetRecordId, // MongoDB ID
+            relType: rel.relType!,
             confidence: rel.confidence,
             checksum: computeChecksum(relTexts[index]),
-          } as RelationshipVectorPayload,
+          } satisfies RelationshipVectorPayload,
         };
       });
 
@@ -369,27 +319,20 @@ export async function indexRelationshipEmbeddings(
       // Update or create GraphEmbeddingMetadata using MongoDB IDs
       for (let j = 0; j < batch.length; j++) {
         const rel = batch[j];
-        const relId = `rel_${rel.sourceId}_${rel.type}_${rel.targetId}`;
         const embeddedChecksum = computeChecksum(relTexts[j]);
         const qdrantId = points[j].id;
 
-        await GraphEmbeddingMetadata.findOneAndUpdate(
-          { _id: relId },
+        await GraphEmbeddingMetadata.updateOne(
+          { memgraphId: rel.memgraphId },
           {
             $set: {
               itemType: "relationship",
-              sourceId: rel.memgraphSourceId, // Store Memgraph ID for reference
-              targetId: rel.memgraphTargetId, // Store Memgraph ID for reference
-              relType: rel.type,
               qdrantId: qdrantId,
               embeddedChecksum: embeddedChecksum,
               embeddedAt: new Date(),
               embeddingModelVersion: env.LLM_EMBEDDING_MODEL,
-              lastUpdatedBy: source,
-              source: source,
             },
-          },
-          { upsert: true }
+          }
         );
       }
     } catch (err) {

--- a/packages/server/src/services/indexing/graph/graph-indexer.ts
+++ b/packages/server/src/services/indexing/graph/graph-indexer.ts
@@ -741,7 +741,9 @@ export const indexAllRecords = async (
           entityIdToNormalizedName.set(id, normalizedName);
         }
 
-        const entityMetadataOps = nodes.map((node) => {
+        const entityMetadataOps = nodes.map<
+          Parameters<typeof GraphEmbeddingMetadata.bulkWrite>[0][0]
+        >((node) => {
           // Calculate content checksum for this entity
           const contentChecksum = calculateEmbeddingChecksum({
             entityType: node.type,
@@ -757,16 +759,15 @@ export const indexAllRecords = async (
 
           return {
             updateOne: {
-              filter: { _id: node.id },
+              filter: { memgraphId: node.id },
               update: {
                 $set: {
                   itemType: "entity",
-                  entityId: node.id,
+                  memgraphId: node.id,
                   entityType: node.type,
                   entityDescription: node.description, // Store LLM-extracted description
-                  source: source,
                   contentChecksum: contentChecksum,
-                  lastUpdatedBy: source,
+                  lastUpdatedBy: documentIds[documentIds.length - 1],
                 },
                 $addToSet: {
                   sources: source,
@@ -1061,17 +1062,17 @@ export const indexAllRecords = async (
 
           return {
             updateOne: {
-              filter: { _id: relId },
+              filter: { memgraphId: relId },
               update: {
                 $set: {
                   itemType: "relationship",
+                  memgraphId: relId,
                   sourceId: rel.sourceId,
                   targetId: rel.targetId,
                   relType: rel.type,
                   relationshipDescription: description, // Store LLM-extracted description
-                  source: source,
                   contentChecksum: contentChecksum,
-                  lastUpdatedBy: source,
+                  lastUpdatedBy: documentIds[documentIds.length - 1],
                 },
                 $addToSet: {
                   sources: source,

--- a/packages/server/src/services/search/lightrag-query.ts
+++ b/packages/server/src/services/search/lightrag-query.ts
@@ -16,13 +16,14 @@ import OpenAI from "openai";
 import {
   LightRAGQuery,
   LightRAGResponse,
-  LightRAGChunk,
+  LightRAGRecord,
   LightRAGChunkFull,
   LightRAGEntity,
   LightRAGRelationship,
   ExtractedKeywords,
 } from "../../types/lightrag.types.js";
 import logger from "../../utils/logger.js";
+import { GraphEmbeddingMetadata } from "../../models/graph-embedding-metadata.model.js";
 
 // ============================================
 // Dependencies Interface
@@ -70,7 +71,7 @@ export async function lightragQuery(
   }
 
   // Execute mode-specific retrieval
-  let chunks: LightRAGChunk[];
+  let records: LightRAGRecord[];
   let vectorMatches = 0;
   let graphExpanded = 0;
   let reranked = false;
@@ -78,34 +79,34 @@ export async function lightragQuery(
   switch (mode) {
     case "naive": {
       const result = await naiveMode(params, deps);
-      chunks = result.chunks;
+      records = result.chunks;
       vectorMatches = result.vectorMatches;
       break;
     }
     case "local": {
       const result = await localMode(params, keywords, deps);
-      chunks = result.chunks;
+      records = result.records;
       vectorMatches = result.vectorMatches;
       graphExpanded = result.graphExpanded;
       break;
     }
     case "global": {
       const result = await globalMode(params, keywords, deps);
-      chunks = result.chunks;
+      records = result.records;
       vectorMatches = result.vectorMatches;
       graphExpanded = result.graphExpanded;
       break;
     }
     case "hybrid": {
       const result = await hybridMode(params, keywords, deps);
-      chunks = result.chunks;
+      records = result.chunks;
       vectorMatches = result.vectorMatches;
       graphExpanded = result.graphExpanded;
       break;
     }
     case "mix": {
       const result = await mixMode(params, keywords, deps);
-      chunks = result.chunks;
+      records = result.chunks;
       vectorMatches = result.vectorMatches;
       graphExpanded = result.graphExpanded;
       reranked = result.reranked;
@@ -117,7 +118,7 @@ export async function lightragQuery(
 
   // Add full content if requested
   if (responseFormat === "full") {
-    chunks = await enrichWithFullContent(chunks, deps.recordStore);
+    records = await enrichWithFullContent(records, deps.recordStore);
   }
 
   const processingTime = Date.now() - startTime;
@@ -125,17 +126,17 @@ export async function lightragQuery(
   logger.info({
     msg: "[LightRAG] Query complete",
     processingTime,
-    chunks: chunks.length,
-    documents: countUniqueDocuments(chunks),
+    chunks: records.length,
+    documents: countUniqueDocuments(records),
   });
 
-  const uniqueDocIds = Array.from(new Set(chunks.map((c) => c.document_id)));
+  const uniqueDocIds = Array.from(new Set(records.map((c) => c.document_id)));
 
-  const records = await RecordModel.find({ _id: { $in: uniqueDocIds } }).lean();
+  const results = await RecordModel.find({ _id: { $in: uniqueDocIds } }).lean();
 
-  const sortedChunks = chunks.sort((a, b) => b.score - a.score);
+  const sortedChunks = records.sort((a, b) => b.score - a.score);
 
-  return records
+  return results
     .sort((a, b) => {
       const aScore =
         sortedChunks.find((c) => c.document_id === a._id)?.score || 0;
@@ -158,7 +159,7 @@ export async function lightragQuery(
 async function naiveMode(
   params: LightRAGQuery,
   deps: LightRAGDependencies
-): Promise<{ chunks: LightRAGChunk[]; vectorMatches: number }> {
+): Promise<{ chunks: LightRAGRecord[]; vectorMatches: number }> {
   logger.info({ msg: `[LightRAG] Running naive mode (vector-only)` });
 
   // Generate embedding
@@ -195,7 +196,7 @@ async function localMode(
   keywords: ExtractedKeywords,
   deps: LightRAGDependencies
 ): Promise<{
-  chunks: LightRAGChunk[];
+  records: LightRAGRecord[];
   vectorMatches: number;
   graphExpanded: number;
 }> {
@@ -227,14 +228,13 @@ async function localMode(
   const allRelationships = [...entityRelationships, ...graphRelationships];
 
   // Get chunks
-  const chunks = await getChunksForEntities(
+  const records = await getRecordsForEntities(
     entities,
-    params.chunk_top_k || 20,
-    deps.recordStore
+    params.chunk_top_k || 20
   );
 
   return {
-    chunks,
+    records,
     vectorMatches: entities.length,
     graphExpanded: allRelationships.length,
   };
@@ -245,7 +245,7 @@ async function globalMode(
   keywords: ExtractedKeywords,
   deps: LightRAGDependencies
 ): Promise<{
-  chunks: LightRAGChunk[];
+  records: LightRAGRecord[];
   vectorMatches: number;
   graphExpanded: number;
 }> {
@@ -269,14 +269,13 @@ async function globalMode(
   const entities = await getEntitiesByIds(Array.from(entityIds), deps);
 
   // Get chunks
-  const chunks = await getChunksForEntities(
+  const records = await getRecordsForEntities(
     entities,
-    params.chunk_top_k || 20,
-    deps.recordStore
+    params.chunk_top_k || 20
   );
 
   return {
-    chunks,
+    records,
     vectorMatches: relationships.length,
     graphExpanded: entities.length,
   };
@@ -287,7 +286,7 @@ async function hybridMode(
   keywords: ExtractedKeywords,
   deps: LightRAGDependencies
 ): Promise<{
-  chunks: LightRAGChunk[];
+  chunks: LightRAGRecord[];
   vectorMatches: number;
   graphExpanded: number;
 }> {
@@ -301,8 +300,8 @@ async function hybridMode(
 
   // Merge and deduplicate
   const chunks = deduplicateChunks([
-    ...localResult.chunks,
-    ...globalResult.chunks,
+    ...localResult.records,
+    ...globalResult.records,
   ]);
 
   const limitedChunks = chunks.slice(0, params.chunk_top_k || 20);
@@ -319,7 +318,7 @@ async function mixMode(
   keywords: ExtractedKeywords,
   deps: LightRAGDependencies
 ): Promise<{
-  chunks: LightRAGChunk[];
+  chunks: LightRAGRecord[];
   vectorMatches: number;
   graphExpanded: number;
   reranked: boolean;
@@ -393,36 +392,40 @@ async function searchEntitiesByKeywords(
     scoreThreshold: scoreThreshold || 0.5,
   });
 
+  const graphEmbeddingMetadata = await GraphEmbeddingMetadata.find({
+    _id: { $in: results.map((r) => r.payload.graphEmbeddingMetadataId) },
+  }).lean();
+
   // Fetch full records from MongoDB using entityId (which is now the MongoDB document ID)
-  const recordIds = results
-    .map((r) => r.payload.mongoId)
-    .filter((id): id is string => id !== undefined && id !== null);
+  const recordIds = Array.from(
+    new Set(graphEmbeddingMetadata.map((i) => i.sourceDocumentIds).flat())
+  );
 
   const records = await RecordModel.find({ _id: { $in: recordIds } }).lean();
-  const recordMap = new Map(records.map((r) => [r._id, r]));
 
-  const entities = results
-    .map<LightRAGEntity>((result) => {
-      const recordId = result.payload.mongoId;
-
-      const record = recordMap.get(recordId)!;
-
-      return {
-        id: record._id,
-        name: record.title,
-        type: record.recordType,
-        description: record.content.substring(0, 200),
-        degree: result.payload.degree,
-        rank: calculateNodeRank(result.payload.degree),
-        source: record.source,
-        sourceId: record.sourceId,
-        date: record.primaryDate?.toISOString(),
-        relevance_score: result.score,
-      };
-    })
-    .filter((e) => e !== null)
-    // Sort by degree (graph centrality)
-    .sort((a, b) => b.degree - a.degree);
+  const entities = records.map<LightRAGEntity>((record) => {
+    let relevanceScore = 0;
+    results.forEach((r) => {
+      const metadata = graphEmbeddingMetadata.find(
+        (i) => i._id === r.payload.graphEmbeddingMetadataId
+      );
+      if (metadata?.sourceDocumentIds.includes(record._id)) {
+        if (r.score > relevanceScore) {
+          relevanceScore = r.score;
+        }
+      }
+    });
+    return {
+      id: record._id,
+      name: record.title,
+      type: record.recordType,
+      description: record.content.substring(0, 200),
+      source: record.source,
+      sourceId: record.sourceId,
+      date: record.primaryDate?.toISOString(),
+      relevanceScore,
+    };
+  });
 
   return entities;
 }
@@ -500,7 +503,7 @@ async function getEntitiesByIds(
     recordIds
   );
 
-  const entities: LightRAGEntity[] = records.map((record) => {
+  const entities = records.map<LightRAGEntity>((record) => {
     const degree = degreeCounts.get(record._id) || 0;
 
     return {
@@ -513,7 +516,7 @@ async function getEntitiesByIds(
       source: record.source,
       sourceId: record.sourceId,
       date: record.primaryDate?.toISOString(),
-      relevance_score: 0,
+      relevanceScore: 0,
     };
   });
 
@@ -559,57 +562,54 @@ async function getEntityRelationships(
   return deduplicateRelationships(relationships);
 }
 
-async function getChunksForEntities(
+async function getRecordsForEntities(
   entities: LightRAGEntity[],
-  limit: number,
-  _recordStore: RecordStore
-): Promise<LightRAGChunk[]> {
+  limit: number
+): Promise<LightRAGRecord[]> {
   const records = await RecordModel.find({
     _id: { $in: entities.map((e) => e.id) },
   }).lean();
 
-  const chunks: LightRAGChunk[] = records
+  const lightRAGRecords: LightRAGRecord[] = records
     .sort((a, b) => {
-      const aScore = entities.find((e) => e.id === a._id)?.relevance_score || 0;
-      const bScore = entities.find((e) => e.id === b._id)?.relevance_score || 0;
+      const aScore = entities.find((e) => e.id === a._id)?.relevanceScore || 0;
+      const bScore = entities.find((e) => e.id === b._id)?.relevanceScore || 0;
       return bScore - aScore;
     })
     .map((record) => ({
       id: record._id,
       document_id: record._id,
-      chunk_index: 9,
       title: record.title,
       source: record.source,
       source_id: record.sourceId,
       snippet: record.content.substring(0, 500),
-      score: entities.find((e) => e.id === record._id)?.relevance_score ?? 0,
+      score: entities.find((e) => e.id === record._id)?.relevanceScore ?? 0,
       type: record.recordType,
       people: record.people || [],
       record,
     }));
 
-  return chunks.slice(0, limit);
+  return lightRAGRecords.slice(0, limit);
 }
 
 async function resultsToChunks(
   results: Array<{ id: string; score: number; payload: any }>,
   recordStore: RecordStore
-): Promise<LightRAGChunk[]> {
+): Promise<LightRAGRecord[]> {
   // Extract MongoDB IDs from payload
-  const mongoIds = results.map((r) => r.payload.mongoId);
-  const records = await recordStore.findByIds(mongoIds);
+  const recordIds = results.map((r) => r.payload.recordId);
+  const records = await recordStore.findByIds(recordIds);
   const recordMap = new Map(records.map((r) => [r._id, r]));
 
-  const chunks: LightRAGChunk[] = [];
+  const chunks: LightRAGRecord[] = [];
 
   for (const result of results) {
-    const record = recordMap.get(result.payload.mongoId);
+    const record = recordMap.get(result.payload.recordId);
     if (!record) continue;
 
     chunks.push({
       id: record._id,
       document_id: record._id,
-      chunk_index: 0,
       title: record.title,
       source: record.source,
       source_id: record.sourceId,
@@ -625,9 +625,9 @@ async function resultsToChunks(
 
 async function rerankChunks(
   query: string,
-  chunks: LightRAGChunk[],
+  chunks: LightRAGRecord[],
   reranker: RerankerService
-): Promise<LightRAGChunk[]> {
+): Promise<LightRAGRecord[]> {
   const docs = chunks.map((c) => ({
     id: c.id,
     text: `${c.title}\n${c.snippet}`,
@@ -652,7 +652,7 @@ async function rerankChunks(
 }
 
 async function enrichWithFullContent(
-  chunks: LightRAGChunk[],
+  chunks: LightRAGRecord[],
   recordStore: RecordStore
 ): Promise<LightRAGChunkFull[]> {
   const recordIds = [...new Set(chunks.map((c) => c.document_id))];
@@ -708,7 +708,7 @@ function deduplicateRelationships(
   });
 }
 
-function deduplicateChunks(chunks: LightRAGChunk[]): LightRAGChunk[] {
+function deduplicateChunks(chunks: LightRAGRecord[]): LightRAGRecord[] {
   const seen = new Set<string>();
   return chunks.filter((c) => {
     if (seen.has(c.id)) return false;
@@ -717,7 +717,7 @@ function deduplicateChunks(chunks: LightRAGChunk[]): LightRAGChunk[] {
   });
 }
 
-function countUniqueDocuments(chunks: LightRAGChunk[]): number {
+function countUniqueDocuments(chunks: LightRAGRecord[]): number {
   return new Set(chunks.map((c) => c.document_id)).size;
 }
 

--- a/packages/server/src/stores/vector.store.ts
+++ b/packages/server/src/stores/vector.store.ts
@@ -121,47 +121,20 @@ export class VectorStore {
   }
 
   /**
-   * Search with pre-filtered MongoDB IDs
-   */
-  async searchWithMongoFilter(
-    vector: number[],
-    mongoIds: string[],
-    options?: {
-      limit?: number;
-      scoreThreshold?: number;
-    }
-  ): Promise<
-    Array<{ id: string; score: number; payload: VectorPoint["payload"] }>
-  > {
-    if (mongoIds.length === 0) return [];
-
-    return this.search(vector, {
-      ...options,
-      filter: {
-        must: [
-          {
-            key: "mongoId",
-            match: {
-              any: mongoIds,
-            },
-          },
-        ],
-      },
-    });
-  }
-
-  /**
    * Delete points by MongoDB ID
    */
-  async deleteOutdatedPoints(mongoId: string, checksum: string): Promise<void> {
+  async deleteOutdatedPoints(
+    recordId: string,
+    checksum: string
+  ): Promise<void> {
     await this.qdrant.client.delete(this.collectionName, {
       wait: true,
       filter: {
         must: [
           {
-            key: "mongoId",
+            key: "recordId",
             match: {
-              value: mongoId,
+              value: recordId,
             },
           },
         ],
@@ -271,135 +244,6 @@ export class VectorStore {
   }
 
   /**
-   * Delete all vectors of a specific type
-   */
-  async deleteByType(type: VectorPayloadType): Promise<void> {
-    await this.qdrant.client.delete(this.collectionName, {
-      wait: true,
-      filter: {
-        must: [{ key: "type", match: { value: type } }],
-      },
-    });
-  }
-
-  /**
-   * Delete entity embedding by mongoId
-   */
-  async deleteEntityEmbedding(mongoId: string): Promise<void> {
-    await this.qdrant.client.delete(this.collectionName, {
-      wait: true,
-      filter: {
-        must: [
-          { key: "type", match: { value: "entity" } },
-          { key: "mongoId", match: { value: mongoId } },
-        ],
-      },
-    });
-  }
-
-  /**
-   * Delete relationship embedding by source/target/type
-   */
-  async deleteRelationshipEmbedding(
-    sourceId: string,
-    targetId: string,
-    type: string
-  ): Promise<void> {
-    await this.qdrant.client.delete(this.collectionName, {
-      wait: true,
-      filter: {
-        must: [
-          { key: "type", match: { value: "relationship" } },
-          { key: "sourceId", match: { value: sourceId } },
-          { key: "targetId", match: { value: targetId } },
-          { key: "relType", match: { value: type } },
-        ],
-      },
-    });
-  }
-
-  /**
-   * Delete all embeddings for a source
-   */
-  async deleteBySource(source: SourceType): Promise<{
-    entities: number;
-    relationships: number;
-  }> {
-    // Get counts before deletion
-    const entityCount = await this.qdrant.client.count(this.collectionName, {
-      filter: {
-        must: [
-          { key: "type", match: { value: "entity" } },
-          { key: "source", match: { value: source } },
-        ],
-      },
-    });
-
-    const relCount = await this.qdrant.client.count(this.collectionName, {
-      filter: {
-        must: [
-          { key: "type", match: { value: "relationship" } },
-          { key: "sourceId", match: { any: [`${source}_`] } },
-        ],
-      },
-    });
-
-    // Delete entity embeddings
-    await this.qdrant.client.delete(this.collectionName, {
-      wait: true,
-      filter: {
-        must: [
-          { key: "type", match: { value: "entity" } },
-          { key: "source", match: { value: source } },
-        ],
-      },
-    });
-
-    // Delete relationship embeddings (filter by sourceId prefix)
-    await this.qdrant.client.delete(this.collectionName, {
-      wait: true,
-      filter: {
-        must: [{ key: "type", match: { value: "relationship" } }],
-      },
-    });
-
-    return {
-      entities: entityCount.count,
-      relationships: relCount.count,
-    };
-  }
-
-  /**
-   * Delete entity embeddings in batch by mongoIds
-   */
-  async deleteEntityEmbeddingsBatch(mongoIds: string[]): Promise<number> {
-    if (mongoIds.length === 0) return 0;
-
-    // Get count before deletion
-    const countResult = await this.qdrant.client.count(this.collectionName, {
-      filter: {
-        must: [
-          { key: "type", match: { value: "entity" } },
-          { key: "mongoId", match: { any: mongoIds } },
-        ],
-      },
-    });
-
-    // Delete
-    await this.qdrant.client.delete(this.collectionName, {
-      wait: true,
-      filter: {
-        must: [
-          { key: "type", match: { value: "entity" } },
-          { key: "mongoId", match: { any: mongoIds } },
-        ],
-      },
-    });
-
-    return countResult.count;
-  }
-
-  /**
    * Delete embeddings by their vector IDs
    */
   async deleteByIds(ids: string[]): Promise<void> {
@@ -411,88 +255,6 @@ export class VectorStore {
         must: [{ key: "id", match: { any: ids } }],
       },
     });
-  }
-
-  /**
-   * Clean up orphaned embeddings (not in MongoDB/Memgraph anymore)
-   */
-  async cleanupOrphanedEmbeddings(
-    validMongoIds: string[],
-    validRelationships: Array<{
-      sourceId: string;
-      targetId: string;
-      type: string;
-    }>
-  ): Promise<{ entities: number; relationships: number }> {
-    // Get all entity embeddings
-    const allEntities = await this.search([0, 0, 0], {
-      limit: 100000,
-      filter: {
-        must: [{ key: "type", match: { value: "entity" } }],
-      },
-    });
-
-    // Find orphaned entities (mongoId not in validMongoIds)
-    const validIdSet = new Set(validMongoIds);
-    const orphanedEntityIds: string[] = [];
-
-    for (const entity of allEntities) {
-      const payload = entity.payload as EntityVectorPayload;
-      if (!validIdSet.has(payload.mongoId as string)) {
-        orphanedEntityIds.push(entity.id);
-      }
-    }
-
-    // Delete orphaned entities
-    if (orphanedEntityIds.length > 0) {
-      await this.qdrant.client.delete(this.collectionName, {
-        wait: true,
-        filter: {
-          must: [{ key: "id", match: { any: orphanedEntityIds } }],
-        },
-      });
-    }
-
-    // Get all relationship embeddings
-    const allRelationships = await this.search([0, 0, 0], {
-      limit: 100000,
-      filter: {
-        must: [{ key: "type", match: { value: "relationship" } }],
-      },
-    });
-
-    // Build set of valid relationships
-    const validRelSet = new Set(
-      validRelationships.map((r) => `${r.sourceId}_${r.type}_${r.targetId}`)
-    );
-
-    const orphanedRelIds: string[] = [];
-    for (const rel of allRelationships) {
-      const payload = rel.payload as RelationshipVectorPayload;
-      const key = `${payload.sourceId}_${payload.relType}_${payload.targetId}`;
-      if (!validRelSet.has(key)) {
-        orphanedRelIds.push(rel.id);
-      }
-    }
-
-    // Delete orphaned relationships
-    if (orphanedRelIds.length > 0) {
-      await this.qdrant.client.delete(this.collectionName, {
-        wait: true,
-        filter: {
-          must: [{ key: "id", match: { any: orphanedRelIds } }],
-        },
-      });
-    }
-
-    logger.info(
-      `Cleaned up ${orphanedEntityIds.length} orphaned entity embeddings and ${orphanedRelIds.length} orphaned relationship embeddings`
-    );
-
-    return {
-      entities: orphanedEntityIds.length,
-      relationships: orphanedRelIds.length,
-    };
   }
 }
 

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -26,7 +26,7 @@ export type VectorPayloadType = "chunk" | "entity" | "relationship";
 
 export interface ChunkVectorPayload extends Record<string, unknown> {
   type: "chunk";
-  mongoId: string;
+  recordId: string;
   checksum: string;
   chunkIndex: number;
   chunkStart: number;
@@ -35,13 +35,9 @@ export interface ChunkVectorPayload extends Record<string, unknown> {
 
 export interface EntityVectorPayload extends Record<string, unknown> {
   type: "entity";
-  // Global entity from Memgraph
-  entityId: string; // Global entity ID from Memgraph (required)
-  entityType: string; // Entity type from Memgraph (required)
-  mongoId: string; // Record ID from MongoDB (required)
+  graphEmbeddingMetadataId: string; // ID from GraphEmbeddingMetadata
   // Shared fields
   source: SourceType;
-  degree: number; // Graph centrality (cached)
   checksum: string;
 }
 

--- a/packages/server/src/types/lightrag.types.ts
+++ b/packages/server/src/types/lightrag.types.ts
@@ -59,13 +59,11 @@ export interface LightRAGEntity {
   name: string;
   type: string;
   description?: string;
-  degree: number;
-  rank: number;
   source?: SourceType;
   sourceId?: string;
   url?: string;
   date?: string;
-  relevance_score: number;
+  relevanceScore: number;
 }
 
 export interface LightRAGRelationship {
@@ -77,17 +75,16 @@ export interface LightRAGRelationship {
   confidence: number;
   weight: number;
   rank: number;
-  relevance_score?: number;
+  relevanceScore?: number;
 }
 
 // ============================================
 // Chunk Result (Agent-Friendly Response)
 // ============================================
 
-export interface LightRAGChunk {
+export interface LightRAGRecord {
   // Chunk identity
   id: string;
-  chunk_index?: number; // Which chunk of the document (0, 1, 2...)
 
   // Document reference
   document_id: string; // Parent document ID
@@ -110,7 +107,7 @@ export interface LightRAGChunk {
   people?: string[]; // People mentioned
 }
 
-export interface LightRAGChunkFull extends LightRAGChunk {
+export interface LightRAGChunkFull extends LightRAGRecord {
   // Full mode additions
   full_content: string; // Complete document text
   position?: {


### PR DESCRIPTION
…itions

- Replace manual TypeScript interfaces with InferSchemaType for type safety
- Remove redundant fields: `entityId`, `source` (keeping `sources` array only)
- Add `memgraphId` field with index for better Memgraph integration
- Rename `IGraphEmbeddingMetadata` to inferred type from schema
- Update `LightRAGChunk` references to `LightRAGRecord` for consistency
- Streamline schema by deriving types directly from Mongoose schema definition

This refactor improves type safety by using Mongoose's schema inference capabilities and eliminates manual type synchronization between interfaces and schemas. The changes also simplify the data model by removing duplicate tracking fields.